### PR TITLE
nodeのバージョンが12.22.0より低い場合はエラーを表示するようにする

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,8 @@
     "prettier": "^2.5.0",
     "storybook-addon-next": "^1.3.1",
     "typescript": "^4.2.4"
+  },
+  "engines": {
+    "node": ">=12.22.0"
   }
 }


### PR DESCRIPTION
close #27 

nodeのバージョンが12.22.0より低い場合に `yarn install` するとエラーを表示するようにしました。
検証お願いします。