### PR TITLE
eslint のルールに import/order を追加

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,23 @@
 {
-  "extends": ["next/core-web-vitals", "next", "prettier"]
+  "extends": ["next/core-web-vitals", "next", "prettier"],
+  "rules": {
+    "import/order": [
+      "warn",
+      {
+        "groups": [
+          "builtin",
+          "external",
+          "internal",
+          "parent",
+          "sibling",
+          "index",
+          "object",
+          "type"
+        ],
+        "newlines-between": "always",
+        "pathGroupsExcludedImportTypes": ["builtin"],
+        "alphabetize": { "order": "asc", "caseInsensitive": true }
+      }
+    ]
+  }
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,8 @@
-import type { AppProps } from 'next/app';
-import Head from 'next/head';
-import '../styles/globals.css';
 import 'modern-css-reset/dist/reset.min.css';
+import Head from 'next/head';
+
+import type { AppProps } from 'next/app';
+import '../styles/globals.css';
 
 const MyApp = ({ Component, pageProps }: AppProps) => {
   return (


### PR DESCRIPTION
import の順序を並び替えてくれる設定を追加しましたのでご確認よろしくお願い致します。
※ extends 内にある next で eslint-plugin-import をインポートしているため、特段設定しなくてもルールを追加できるようになっております。

import order に関する説明
https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/order.md