### PR TITLE
Dialogコンポーネントの背景の修正

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -2,6 +2,7 @@ import { ArgsTable, Title } from '@storybook/addon-docs';
 import 'modern-css-reset/dist/reset.min.css';
 import React from 'react';
 import '../src/styles/globals.css';
+import { colors } from '../src/styles/themes.css';
 
 export const parameters = {
   actions: { argTypesRegex: '^on[A-Z].*' },
@@ -18,5 +19,13 @@ export const parameters = {
         <ArgsTable />
       </>
     ),
+  },
+  backgrounds: {
+    values: [
+      {
+        name: 'blue',
+        value: colors.blue,
+      },
+    ],
   },
 };

--- a/src/components/ui/Dialog/index.stories.tsx
+++ b/src/components/ui/Dialog/index.stories.tsx
@@ -8,6 +8,9 @@ export default {
   component: Dialog,
   parameters: {
     controls: { hideNoControlsWarning: true },
+    backgrounds: {
+      default: 'blue',
+    },
   },
 } as ComponentMeta<typeof Dialog>;
 

--- a/src/components/ui/Dialog/styles.css.ts
+++ b/src/components/ui/Dialog/styles.css.ts
@@ -10,11 +10,9 @@ const styles = {
       width: '100%',
       height: '100%',
       overflowY: 'auto',
-      opacity: 0.3,
     },
     sprinkles({
       position: 'fixed',
-      background: 'black',
     }),
   ]),
   container: style([

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -1,15 +1,17 @@
 import { createGlobalTheme } from '@vanilla-extract/css';
 
+export const colors = {
+  white: '#FEFEFE',
+  black: '#333333',
+  silver: '#F8F8F8',
+  gray: '#C8C8C8',
+  blue: '#1E1ADE',
+  lightBlue: '#0080FF',
+  purple: '#B01CF6',
+} as const;
+
 export const vars = createGlobalTheme(':root', {
-  colors: {
-    white: '#FEFEFE',
-    black: '#333333',
-    silver: '#F8F8F8',
-    gray: '#C8C8C8',
-    blue: '#1E1ADE',
-    lightBlue: '#0080FF',
-    purple: '#B01CF6',
-  },
+  colors: colors,
   spacing: {
     0.5: '4px',
     1: '8px',


### PR DESCRIPTION
## 概要

Dialogコンポーネントの背景を修正しました。また、Storybookの[Backgroundsアドオン](https://storybook.js.org/docs/react/essentials/backgrounds)を使用してDialogコンポーネント時は背景色を青にするようにしました。

## スクリーンショット

![Storybook上でDialogコンポーネントを表示している画像。Dialogコンポーネントの背景が青色になっている。](https://user-images.githubusercontent.com/30039352/210816718-d60cddbc-e4cd-4706-8781-fe285d725b80.png)
