### PR TITLE
Headingコンポーネントの作成

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,12 +5,8 @@ import '../src/styles/globals.css';
 import { colors } from '../src/styles/themes.css';
 
 export const parameters = {
-  actions: { argTypesRegex: '^on[A-Z].*' },
   controls: {
-    matchers: {
-      color: /(background|color)$/i,
-      date: /Date$/,
-    },
+    hideNoControlsWarning: true,
   },
   docs: {
     page: () => (

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,5 +3,6 @@
   "editor.formatOnPaste": true,
   "editor.formatOnSave": true,
   "editor.formatOnType": true,
-  "editor.codeActionsOnSave": ["source.organizeImports", "source.fixAll.eslint"]
+  "editor.codeActionsOnSave": ["source.organizeImports", "source.fixAll.eslint"],
+  "cSpell.words": ["clsx"]
 }

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@headlessui/react": "^1.7.4",
     "@mui/icons-material": "^5.10.9",
     "@mui/material": "^5.10.9",
+    "clsx": "^1.2.1",
     "next": "latest",
     "react": "^17.0.2",
     "react-dom": "^17.0.2"

--- a/src/components/ui/Dialog/index.stories.tsx
+++ b/src/components/ui/Dialog/index.stories.tsx
@@ -7,7 +7,6 @@ export default {
   title: 'Dialog',
   component: Dialog,
   parameters: {
-    controls: { hideNoControlsWarning: true },
     backgrounds: {
       default: 'blue',
     },

--- a/src/components/ui/Heading/index.stories.tsx
+++ b/src/components/ui/Heading/index.stories.tsx
@@ -1,0 +1,17 @@
+import { ComponentMeta, Story } from '@storybook/react';
+
+import { Heading } from '.';
+
+export default {
+  title: 'Heading',
+  component: Heading,
+} as ComponentMeta<typeof Heading>;
+
+export const _Heading: Story = () => {
+  return (
+    <div>
+      <Heading tag="h1">Heading level 1</Heading>
+      <Heading tag="h2">Heading level 2</Heading>
+    </div>
+  );
+};

--- a/src/components/ui/Heading/index.tsx
+++ b/src/components/ui/Heading/index.tsx
@@ -1,0 +1,26 @@
+import clsx from 'clsx';
+import { ReactNode } from 'react';
+
+import { styles } from './styles.css';
+
+export type HeadingProps = {
+  /**
+   * 見出しのタグ
+   */
+  tag: 'h1' | 'h2';
+  /**
+   * 見出しのコンテンツ
+   */
+  children: ReactNode;
+};
+
+const Heading = ({ tag = 'h1', children }: HeadingProps) => {
+  switch (tag) {
+    case 'h1':
+      return <h1 className={clsx(styles.common, styles.h1)}>{children}</h1>;
+    case 'h2':
+      return <h2 className={clsx(styles.common, styles.h2)}>{children}</h2>;
+  }
+};
+
+export { Heading };

--- a/src/components/ui/Heading/styles.css.ts
+++ b/src/components/ui/Heading/styles.css.ts
@@ -1,0 +1,23 @@
+import { sprinkles } from '../../../styles/sprinkles.css';
+
+const styles = {
+  common: sprinkles({
+    lineHeight: 'heading',
+    fontWeight: 'bold',
+    color: 'black',
+  }),
+  h1: sprinkles({
+    fontSize: {
+      mobile: 32,
+      desktop: 48,
+    },
+  }),
+  h2: sprinkles({
+    fontSize: {
+      mobile: 24,
+      desktop: 36,
+    },
+  }),
+};
+
+export { styles };

--- a/src/styles/sprinkles.css.ts
+++ b/src/styles/sprinkles.css.ts
@@ -43,6 +43,23 @@ const colorProperties = defineProperties({
   },
 });
 
-export const sprinkles = createSprinkles(responsiveProperties, colorProperties);
+const lineHeightProperties = defineProperties({
+  properties: {
+    lineHeight: vars.lineHeight,
+  },
+});
+
+const fontWeightProperties = defineProperties({
+  properties: {
+    fontWeight: vars.fontWeight,
+  },
+});
+
+export const sprinkles = createSprinkles(
+  responsiveProperties,
+  colorProperties,
+  lineHeightProperties,
+  fontWeightProperties
+);
 
 export type Sprinkles = Parameters<typeof sprinkles>[0];

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -43,4 +43,12 @@ export const vars = createGlobalTheme(':root', {
     48: '3rem',
     64: '4rem',
   },
+  lineHeight: {
+    text: '1.8',
+    heading: '1.3',
+  },
+  fontWeight: {
+    normal: 'normal',
+    bold: 'bold',
+  },
 });


### PR DESCRIPTION
close #78 

## 概要

Headingコンポーネントを作成しました。
作成するにあたり、classNameで複数のスタイルを設定するために[clsx](https://github.com/lukeed/clsx)を導入しました。
また、Storybookのcontrolsも併せて修正しました。（controlsは使用しない想定のため全体で `hideNoControlsWarning: true` が反映されるように設定しました。）

## スクリーンショット

![Storybook上でHeadingコンポーネントが表示された画像](https://user-images.githubusercontent.com/30039352/211145366-5553b4d9-fb73-4a63-95cd-d4ac8ad8f0b5.png)
