### PR TITLE
Headingコンポーネントのtagをオプショナルにする

### DIFF
--- a/src/components/ui/Heading/index.stories.tsx
+++ b/src/components/ui/Heading/index.stories.tsx
@@ -10,7 +10,7 @@ export default {
 export const _Heading: Story = () => {
   return (
     <div>
-      <Heading tag="h1">Heading level 1</Heading>
+      <Heading>Heading level 1</Heading>
       <Heading tag="h2">Heading level 2</Heading>
     </div>
   );

--- a/src/components/ui/Heading/index.tsx
+++ b/src/components/ui/Heading/index.tsx
@@ -7,7 +7,7 @@ export type HeadingProps = {
   /**
    * 見出しのタグ
    */
-  tag: 'h1' | 'h2';
+  tag?: 'h1' | 'h2';
   /**
    * 見出しのコンテンツ
    */


### PR DESCRIPTION
## 概要

Headingコンポーネントのtag propをオプショナルにし、storiesファイルでも省略するようにしました。