### PR TITLE
クリック後にフォーカスされないように:focus-visibleを使用するように修正

### DIFF
--- a/src/components/ui/Button/styles.css.ts
+++ b/src/components/ui/Button/styles.css.ts
@@ -13,10 +13,10 @@ const styles = {
       color: 'white',
       backgroundColor: 'blue',
       outlineColor: {
-        focus: 'lightBlue',
+        focusVisible: 'lightBlue',
       },
       opacity: {
-        focus: 0.8,
+        focusVisible: 0.8,
         hover: 0.8,
         disabled: 0.3,
         disabledHover: 0.3,

--- a/src/styles/sprinkles.css.ts
+++ b/src/styles/sprinkles.css.ts
@@ -53,7 +53,7 @@ const selectorProperties = defineProperties({
   conditions: {
     default: {},
     hover: { selector: '&:hover' },
-    focus: { selector: '&:focus' },
+    focusVisible: { selector: '&:focus-visible' },
     disabled: { selector: '&:disabled' },
     disabledHover: { selector: '&:disabled:hover' },
   },


### PR DESCRIPTION
## 概要

クリック後にフォーカスされないように:focus-visibleを使用するように修正しました。

## 動画

https://user-images.githubusercontent.com/30039352/211173219-1ce63d6f-1976-4d13-aacc-ece27ba14d8c.mov

