### PR TITLE
🎨 chore: git commit時にgit czを実行するよう改善

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+exec < /dev/tty && yarn commit --hook || true

--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-exec < /dev/tty && yarn commit --hook || true
+exec < /dev/tty && yarn git-cz --hook || true

--- a/README.md
+++ b/README.md
@@ -59,9 +59,6 @@ $ yarn storybook
 # Storybookのビルド
 $ yarn build-storybook
 
-# コミット時はgit commitではなく以下のnpm scriptsを実行(git-czの実行)
-$ yarn commit
-
 # pathpidaの実行
 $ yarn pathpida
 ```

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "prepare": "husky install",
     "storybook": "start-storybook -p 6006 -s ./public",
     "build-storybook": "build-storybook -s public",
-    "commit": "git cz",
     "pathpida": "pathpida --ignorePath .gitignore && prettier --write src/lib/"
   },
   "lint-staged": {


### PR DESCRIPTION
問題が完全に解消したわけではなくて、
- git czでコミットメッセージを確定させたあとにVimの画面が出る
- git czを中断(ctrl + c)した際にVimの画面が出る

という問題があります