### PR TITLE
Storybook上でのButtonコンポーネントの配置を修正

### DIFF
--- a/src/components/ui/Button/index.stories.tsx
+++ b/src/components/ui/Button/index.stories.tsx
@@ -12,20 +12,20 @@ export default {
 export const _Button: Story = () => {
   return (
     <dl>
-      <dt>Default</dt>
-      <dd style={{ marginBottom: '16px' }}>
+      <dt style={{ marginBottom: '8px' }}>Default</dt>
+      <dd style={{ marginBottom: '24px' }}>
         <Button type="button" onClick={action('clicked')}>
           Default Button
         </Button>
       </dd>
-      <dt>Disabled</dt>
-      <dd style={{ marginBottom: '16px' }}>
+      <dt style={{ marginBottom: '8px' }}>Disabled</dt>
+      <dd style={{ marginBottom: '24px' }}>
         <Button type="button" disabled onClick={action('clicked')}>
           Disabled Button
         </Button>
       </dd>
-      <dt>Circle</dt>
-      <dd style={{ marginBottom: '16px' }}>
+      <dt style={{ marginBottom: '8px' }}>Circle</dt>
+      <dd style={{ marginBottom: '24px' }}>
         <Button type="button" variant="circle" onClick={action('clicked')}>
           {/* TODO: アイコンコンポーネントに置き換える */}
           <Close sx={{ fontSize: 24 }} />


### PR DESCRIPTION
## 概要

見やすいように、Storybook上でButtonコンポーネントの説明に対してmarginを追加し、配置を修正しました。

## スクリーンショット

![Storybook上でButtonコンポーネントが表示されている画像](https://user-images.githubusercontent.com/30039352/212363281-1f86c222-fc4f-41d7-a537-0ae6f875628a.png)
