### PR TITLE
GitHub Actionsの改善

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -16,7 +16,7 @@ jobs:
           node-version: 18.13.0
 
       - name: Install dependencies
-        run: npm ci
+        run: yarn install --immutable --immutable-cache --check-cache
 
       - name: Publish to Chromatic
         uses: chromaui/action@v1

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -17,6 +17,13 @@ jobs:
         with:
           node-version: 18.13.0
 
+      - name: Cache yarn cache directory
+        uses: actions/cache@v3
+        with:
+          path: ~/.yarn-cache
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: ${{ runner.os }}-yarn-
+
       - name: Install dependencies
         run: yarn install --immutable --immutable-cache --check-cache
 

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout main branch
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Use Node.js
         uses: actions/setup-node@v3

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,14 +1,23 @@
-name: 'Chromatic'
+name: Chromatic
 
 on: push
 
 jobs:
   chromatic-deployment:
     runs-on: ubuntu-latest
+
     steps:
-      - uses: actions/checkout@v1
+      - name: Checkout main branch
+        uses: actions/checkout@v3
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.13.0
+
       - name: Install dependencies
-        run: yarn
+        run: npm ci
+
       - name: Publish to Chromatic
         uses: chromaui/action@v1
         with:


### PR DESCRIPTION
- 設定が読みやすいように空白を追加
- `actions/checkout` のバージョンを `v1` -> `v3` へアップデート
  - それに伴う仕様変更でデフォルトではGitの履歴が最新しか取得できなくなっていたため修正
- `actions/setup-node` を使用してNode.jsのバージョンを明示的に指定(ひとまず今のLTS)
- CI用のyarn installコマンドに変更
- `~/.yarn-cache` を使用するようにして高速化