### PR TITLE
バッジコンポーネントの作成

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@vanilla-extract/babel-plugin": "^1.1.4",
     "@vanilla-extract/css": "^1.6.8",
     "@vanilla-extract/next-plugin": "^2.0.1",
+    "@vanilla-extract/recipes": "^0.3.0",
     "@vanilla-extract/sprinkles": "^1.5.1",
     "babel-loader": "^8.2.3",
     "chromatic": "^6.4.3",

--- a/src/components/ui/Badge/index.stories.tsx
+++ b/src/components/ui/Badge/index.stories.tsx
@@ -1,0 +1,19 @@
+import { ComponentMeta, Story } from '@storybook/react';
+
+import { Badge } from '.';
+
+export default {
+  title: 'Badge',
+  component: Badge,
+} as ComponentMeta<typeof Badge>;
+
+export const _Badge: Story = () => {
+  return (
+    <dl>
+      <dt style={{ marginBottom: '8px' }}>color=&quot;blue&quot;</dt>
+      <dd style={{ marginBottom: '24px' }}>
+        <Badge color="blue">Badge</Badge>
+      </dd>
+    </dl>
+  );
+};

--- a/src/components/ui/Badge/index.tsx
+++ b/src/components/ui/Badge/index.tsx
@@ -1,0 +1,26 @@
+import { ComponentProps, ReactNode } from 'react';
+
+import { BadgeColor, styles } from './styles.css';
+
+type BaseProps = {
+  /**
+   * バッジのカラー
+   */
+  color: BadgeColor;
+  /**
+   * バッジのコンテンツ
+   */
+  children: ReactNode;
+};
+
+export type BadgeProps = BaseProps & Omit<ComponentProps<'span'>, keyof BaseProps>;
+
+const Badge = ({ color, children, ...props }: BadgeProps) => {
+  return (
+    <span {...props} className={styles({ color })}>
+      {children}
+    </span>
+  );
+};
+
+export { Badge };

--- a/src/components/ui/Badge/styles.css.ts
+++ b/src/components/ui/Badge/styles.css.ts
@@ -1,0 +1,36 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { sprinkles } from '@/styles/sprinkles.css';
+import { Color } from '@/styles/themes.css';
+
+export type BadgeColor = Extract<Color, 'blue'>;
+
+const color: { [Key in BadgeColor]: string } = {
+  blue: sprinkles({
+    color: 'white',
+    backgroundColor: 'blue',
+  }),
+};
+
+const styles = recipe({
+  base: style([
+    sprinkles({
+      display: 'inline-block',
+      fontSize: {
+        mobile: 14,
+        desktop: 16,
+      },
+      paddingX: 1,
+      paddingY: 0.5,
+    }),
+    {
+      borderRadius: '16px',
+    },
+  ]),
+  variants: {
+    color,
+  },
+});
+
+export { styles };

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -10,6 +10,8 @@ export const colors = {
   purple: '#B01CF6',
 } as const;
 
+export type Color = keyof typeof colors;
+
 export const spacing = {
   0.5: '4px',
   1: '8px',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3317,6 +3317,11 @@
   resolved "https://registry.yarnpkg.com/@vanilla-extract/private/-/private-1.0.3.tgz#7ec72bc2ff6fe51f9d650f962e8d1989b073690f"
   integrity sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==
 
+"@vanilla-extract/recipes@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@vanilla-extract/recipes/-/recipes-0.3.0.tgz#2d694106cf415e176849d3428b31c9bb2536c93f"
+  integrity sha512-7wXrgfq1oldKdBfCKen4XmSlDmQR+4o0CQ3WnnLfhQaEtI65xJ774yyQF6dD2CC+hHdW2LFKVXgH5NZRbMQ8Sg==
+
 "@vanilla-extract/sprinkles@^1.5.1":
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/@vanilla-extract/sprinkles/-/sprinkles-1.5.1.tgz#3e226e99c597af8bfeafc8f76a7a720b210a29cf"


### PR DESCRIPTION
close #82 

## 概要

バッジコンポーネントを作成しました。
作成にあたり、コンポーネント側から値を渡すために[@vanilla-extract/recipes](https://vanilla-extract.style/documentation/packages/recipes/)を導入しました。
（上記ライブラリを使用しないとtsxファイルでvanilla-extractを実行することとなり、エラーになります。）

## スクリーンショット

<img width="1037" alt="Storybook上にバッジコンポーネントが表示された画像" src="https://user-images.githubusercontent.com/30039352/226097140-03a6ea24-322a-43f8-9f33-e6821473ef9b.png">
