### PR TITLE
テキストエリアコンポーネントの作成

### DIFF
--- a/src/components/ui/Textarea/index.stories.tsx
+++ b/src/components/ui/Textarea/index.stories.tsx
@@ -1,0 +1,39 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { action } from '@storybook/addon-actions';
+import { ComponentMeta, Story } from '@storybook/react';
+import { useForm } from 'react-hook-form';
+import { object, string } from 'zod';
+
+import { Textarea } from '.';
+
+export default {
+  title: 'Textarea',
+  component: Textarea,
+} as ComponentMeta<typeof Textarea>;
+
+const schema = object({
+  description: string().nonempty().max(10),
+});
+
+export const _Textarea: Story = () => {
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm({
+    resolver: zodResolver(schema),
+  });
+  return (
+    <form onSubmit={handleSubmit(action('handleSubmit'))}>
+      <dl>
+        <dt style={{ marginBottom: '8px' }}>
+          <label htmlFor="description">Description</label>
+        </dt>
+        <dd style={{ marginBottom: '24px' }}>
+          <Textarea id="description" register={register} errors={errors} />
+        </dd>
+      </dl>
+      <button type="submit">Submit</button>
+    </form>
+  );
+};

--- a/src/components/ui/Textarea/index.tsx
+++ b/src/components/ui/Textarea/index.tsx
@@ -1,0 +1,44 @@
+import clsx from 'clsx';
+import { ComponentProps } from 'react';
+import { FieldErrors, FieldValues, RegisterOptions, UseFormRegister } from 'react-hook-form';
+
+import { styles } from './styles.css';
+
+type BaseProps = {
+  /**
+   * テキストエリアのID
+   */
+  id: string;
+  /**
+   * テキストエリアのプレースホルダー
+   */
+  placeholder?: string;
+  /**
+   * React Hook Formのregister
+   */
+  register: UseFormRegister<FieldValues>;
+  /**
+   * registerのオプション
+   */
+  options?: RegisterOptions<FieldValues, string>;
+  /**
+   * formStateのerrors
+   */
+  errors: FieldErrors<FieldValues>;
+};
+
+export type TextareaProps = BaseProps & Omit<ComponentProps<'textarea'>, keyof BaseProps>;
+
+const Textarea = ({ id, placeholder, register, options, errors, ...props }: TextareaProps) => {
+  return (
+    <textarea
+      {...props}
+      id={id}
+      className={clsx(styles.textarea, errors[id] && styles.error)}
+      placeholder={placeholder}
+      {...register(id, options)}
+    />
+  );
+};
+
+export { Textarea };

--- a/src/components/ui/Textarea/styles.css.ts
+++ b/src/components/ui/Textarea/styles.css.ts
@@ -1,0 +1,38 @@
+import { style } from '@vanilla-extract/css';
+
+import { sprinkles } from '@/styles/sprinkles.css';
+
+const styles = {
+  // TODO: heightを指定する
+  textarea: style([
+    sprinkles({
+      fontSize: {
+        desktop: 16,
+        mobile: 14,
+      },
+      lineHeight: 'text',
+      color: 'black',
+      paddingX: 1,
+      paddingY: 1.25,
+      borderColor: {
+        default: 'gray',
+        focusVisible: 'blue',
+      },
+    }),
+    {
+      width: '100%',
+      // TODO: rem指定する
+      minHeight: '100px',
+      borderWidth: '1px',
+      borderStyle: 'solid',
+      borderRadius: '5px',
+      resize: 'vertical',
+    },
+  ]),
+  error: sprinkles({
+    borderColor: 'red',
+    backgroundColor: 'lightRed',
+  }),
+};
+
+export { styles };


### PR DESCRIPTION
close #86 

## 概要

テキストエリアコンポーネントを作成しました。
TODOの箇所は Issue #166 で対応します。

## スクリーンショット

### デフォルト

<img width="1027" alt="テキストエリアコンポーネントの画像" src="https://user-images.githubusercontent.com/30039352/233589607-fdf9a87c-2a52-4a21-9a2c-77213d0ae225.png">

### フォーカス

<img width="1032" alt="テキストエリアコンポーネントの画像。フォーカスが当たっている。" src="https://user-images.githubusercontent.com/30039352/233589621-1c10efb3-cad8-4fdf-99a2-dce9a4285333.png">

### エラー

<img width="1031" alt="テキストエリアコンポーネントの画像。エラー時のスタイルが当たっている。" src="https://user-images.githubusercontent.com/30039352/233589626-2be69ff2-6d00-4677-b233-e5059e060bfb.png">
