### PR TITLE
アコーディオンコンポーネントの作成

### DIFF
--- a/.svgrrc.js
+++ b/.svgrrc.js
@@ -1,7 +1,7 @@
 module.exports = {
   typescript: true,
   svgProps: {
-    fill: '{fill}',
+    fill: '{fill ? colors[fill] : colors.black}',
     stroke: '{stroke}',
     'aria-hidden': true,
   },
@@ -20,6 +20,7 @@ module.exports = {
   template: (variables, { tpl }) => {
     return tpl`
       import { IconProps } from '@/components/ui/Icons/props';
+      import { colors } from '@/styles/themes.css';
 
       const ${variables.componentName} = ({ fill, stroke, ...props }: IconProps) => (
         ${variables.jsx}

--- a/src/assets/icons/expandMoreIcon.svg
+++ b/src/assets/icons/expandMoreIcon.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 0 24 24" width="24px" fill="#000000"><path d="M24 24H0V0h24v24z" fill="none" opacity=".87"/><path d="M16.59 8.59L12 13.17 7.41 8.59 6 10l6 6 6-6-1.41-1.41z"/></svg>

--- a/src/components/ui/Accordion/index.stories.tsx
+++ b/src/components/ui/Accordion/index.stories.tsx
@@ -1,0 +1,26 @@
+import { ComponentMeta, Story } from '@storybook/react';
+
+import { isDesktop } from '@/utils/isDesktop';
+
+import { Accordion } from '.';
+
+export default {
+  title: 'Accordion',
+  component: Accordion,
+} as ComponentMeta<typeof Accordion>;
+
+export const _Accordion: Story = () => {
+  return (
+    <>
+      <Accordion defaultOpen={true} buttonText="2023">
+        {'defaultOpen={true}'}
+      </Accordion>
+      <Accordion defaultOpen={false} buttonText="2022">
+        {'defaultOpen={false}'}
+      </Accordion>
+      <Accordion buttonText="2021" defaultOpen={isDesktop()}>
+        {'defaultOpen={isDesktop()} // 画面幅に応じて制御'}
+      </Accordion>
+    </>
+  );
+};

--- a/src/components/ui/Accordion/index.stories.tsx
+++ b/src/components/ui/Accordion/index.stories.tsx
@@ -12,14 +12,14 @@ export default {
 export const _Accordion: Story = () => {
   return (
     <>
-      <Accordion defaultOpen={true} buttonText="2023">
-        {'defaultOpen={true}'}
+      <Accordion isOpen={true} buttonText="2023">
+        {'isOpen={true}'}
       </Accordion>
-      <Accordion defaultOpen={false} buttonText="2022">
-        {'defaultOpen={false}'}
+      <Accordion isOpen={false} buttonText="2022">
+        {'isOpen={false}'}
       </Accordion>
-      <Accordion buttonText="2021" defaultOpen={isDesktop()}>
-        {'defaultOpen={isDesktop()} // 画面幅に応じて制御'}
+      <Accordion buttonText="2021" isOpen={isDesktop()}>
+        {'isOpen={isDesktop()} // 画面幅に応じて制御'}
       </Accordion>
     </>
   );

--- a/src/components/ui/Accordion/index.tsx
+++ b/src/components/ui/Accordion/index.tsx
@@ -1,0 +1,43 @@
+import { Disclosure } from '@headlessui/react';
+import clsx from 'clsx';
+import { ReactNode } from 'react';
+
+import { ExpandMoreIcon } from '../Icons';
+
+import { styles } from './styles.css';
+
+export type AccordionProps = {
+  /**
+   * 初期描画時のアコーディオンの状態
+   */
+  defaultOpen?: boolean;
+  /**
+   * アコーディオンを開閉するためのボタンテキスト
+   */
+  buttonText: string;
+  /**
+   * アコーディオンのコンテンツ
+   */
+  children: ReactNode;
+};
+
+const Accordion = ({ defaultOpen, buttonText, children }: AccordionProps) => {
+  return (
+    <Disclosure defaultOpen={defaultOpen}>
+      {({ open }) => (
+        <>
+          <div className={styles.buttonWrapper}>
+            <Disclosure.Button className={styles.button}>
+              {buttonText}
+              <ExpandMoreIcon className={clsx(styles.icon, open && styles.rotate)} />
+            </Disclosure.Button>
+          </div>
+
+          <Disclosure.Panel>{children}</Disclosure.Panel>
+        </>
+      )}
+    </Disclosure>
+  );
+};
+
+export { Accordion };

--- a/src/components/ui/Accordion/index.tsx
+++ b/src/components/ui/Accordion/index.tsx
@@ -10,7 +10,7 @@ export type AccordionProps = {
   /**
    * 初期描画時のアコーディオンの状態
    */
-  defaultOpen?: boolean;
+  isOpen: boolean;
   /**
    * アコーディオンを開閉するためのボタンテキスト
    */
@@ -21,9 +21,9 @@ export type AccordionProps = {
   children: ReactNode;
 };
 
-const Accordion = ({ defaultOpen, buttonText, children }: AccordionProps) => {
+const Accordion = ({ isOpen, buttonText, children }: AccordionProps) => {
   return (
-    <Disclosure defaultOpen={defaultOpen}>
+    <Disclosure defaultOpen={isOpen}>
       {({ open }) => (
         <>
           <div className={styles.buttonWrapper}>

--- a/src/components/ui/Accordion/styles.css.ts
+++ b/src/components/ui/Accordion/styles.css.ts
@@ -1,0 +1,40 @@
+import { style } from '@vanilla-extract/css';
+
+import { sprinkles } from '@/styles/sprinkles.css';
+
+const styles = {
+  buttonWrapper: style({
+    textAlign: 'center',
+  }),
+  button: style([
+    sprinkles({
+      display: 'inline-flex',
+      alignItems: 'center',
+      gap: 0.5,
+      fontSize: {
+        mobile: 24,
+        desktop: 36,
+      },
+      color: 'black',
+      outlineColor: {
+        focusVisible: 'blue',
+      },
+    }),
+    style({
+      lineHeight: 'normal',
+      backgroundColor: 'transparent',
+      cursor: 'pointer',
+      padding: 0,
+      border: 'none',
+    }),
+  ]),
+  // TODO: width / height のサイズを画面幅に応じて変える
+  icon: style({
+    transition: 'transform 300ms',
+  }),
+  rotate: style({
+    transform: 'rotate(180deg)',
+  }),
+};
+
+export { styles };

--- a/src/components/ui/Icons/CloseIcon.tsx
+++ b/src/components/ui/Icons/CloseIcon.tsx
@@ -1,11 +1,12 @@
 import { IconProps } from '@/components/ui/Icons/props';
+import { colors } from '@/styles/themes.css';
 const SvgCloseIcon = ({ fill, stroke, ...props }: IconProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     height={24}
     viewBox="0 0 24 24"
     width={24}
-    fill={fill}
+    fill={fill ? colors[fill] : colors.black}
     stroke={stroke}
     aria-hidden={true}
     {...props}

--- a/src/components/ui/Icons/ExpandMoreIcon.tsx
+++ b/src/components/ui/Icons/ExpandMoreIcon.tsx
@@ -1,0 +1,17 @@
+import { IconProps } from '@/components/ui/Icons/props';
+const SvgExpandMoreIcon = ({ fill, stroke, ...props }: IconProps) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    height={24}
+    viewBox="0 0 24 24"
+    width={24}
+    fill={fill}
+    stroke={stroke}
+    aria-hidden={true}
+    {...props}
+  >
+    <path d="M24 24H0V0h24v24z" fill="none" opacity={0.87} />
+    <path d="M16.59 8.59 12 13.17 7.41 8.59 6 10l6 6 6-6-1.41-1.41z" />
+  </svg>
+);
+export default SvgExpandMoreIcon;

--- a/src/components/ui/Icons/ExpandMoreIcon.tsx
+++ b/src/components/ui/Icons/ExpandMoreIcon.tsx
@@ -1,11 +1,12 @@
 import { IconProps } from '@/components/ui/Icons/props';
+import { colors } from '@/styles/themes.css';
 const SvgExpandMoreIcon = ({ fill, stroke, ...props }: IconProps) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     height={24}
     viewBox="0 0 24 24"
     width={24}
-    fill={fill}
+    fill={fill ? colors[fill] : colors.black}
     stroke={stroke}
     aria-hidden={true}
     {...props}

--- a/src/components/ui/Icons/index.ts
+++ b/src/components/ui/Icons/index.ts
@@ -1,1 +1,2 @@
 export { default as CloseIcon } from './CloseIcon';
+export { default as ExpandMoreIcon } from './ExpandMoreIcon';

--- a/src/styles/breakpoint.ts
+++ b/src/styles/breakpoint.ts
@@ -1,0 +1,1 @@
+export const breakpoint = 'screen and (min-width: 768px)';

--- a/src/styles/sprinkles.css.ts
+++ b/src/styles/sprinkles.css.ts
@@ -1,11 +1,12 @@
 import { createSprinkles, defineProperties } from '@vanilla-extract/sprinkles';
 
+import { breakpoint } from './breakpoint';
 import { vars } from './themes.css';
 
 const responsiveProperties = defineProperties({
   conditions: {
     mobile: {},
-    desktop: { '@media': 'screen and (min-width: 768px)' },
+    desktop: { '@media': breakpoint },
   },
   defaultCondition: 'mobile',
   properties: {

--- a/src/styles/sprinkles.css.ts
+++ b/src/styles/sprinkles.css.ts
@@ -15,6 +15,7 @@ const responsiveProperties = defineProperties({
     alignItems: ['flex-start', 'center', 'flex-end'],
     justifyContent: ['flex-start', 'center', 'flex-end', 'space-between'],
     flexDirection: ['row', 'row-reverse', 'column', 'column-reverse'],
+    gap: vars.spacing,
     paddingTop: vars.spacing,
     paddingBottom: vars.spacing,
     paddingLeft: vars.spacing,

--- a/src/utils/isDesktop.ts
+++ b/src/utils/isDesktop.ts
@@ -1,0 +1,1 @@
+export const isDesktop = () => window.matchMedia('screen and (min-width: 768px)').matches;


### PR DESCRIPTION
## 概要

アコーディオンコンポーネントを作成しました。また、作成に伴いアイコン使用時にテーマ内で定義したカラーを使用するためにアイコンを生成するための`.svgrrc.js`も修正しました。さらに画面幅に応じて`boolean`を返す`isDesktop`関数も定義しましたので併せて確認お願いします。

## スクリーンショット

<img width="700" alt="Storybook上にアコーディオンコンポーネントが表示されている画像" src="https://user-images.githubusercontent.com/30039352/235358617-2404be62-427a-4d72-b312-6d48001c53dd.png">
