### PR TITLE
アイコンコンポーネントをStorybook上で一覧表示する

### DIFF
--- a/src/components/ui/Icons/index.stories.tsx
+++ b/src/components/ui/Icons/index.stories.tsx
@@ -3,14 +3,12 @@ import { ComponentMeta, Story } from '@storybook/react';
 import * as Icons from '.';
 
 const IconList = () => {
-  const iconComponents = Object.keys(Icons).map((icon) => Icons[icon as keyof typeof Icons]);
-
   return (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
-      {iconComponents.map((IconComponent, index) => (
+      {Object.entries(Icons).map(([iconName, IconComponent], index) => (
         <div key={index} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           <IconComponent />
-          <div>{Object.keys(Icons)[index]}</div>
+          <div>{iconName}</div>
         </div>
       ))}
     </div>

--- a/src/components/ui/Icons/index.stories.tsx
+++ b/src/components/ui/Icons/index.stories.tsx
@@ -2,17 +2,15 @@ import { ComponentMeta, Story } from '@storybook/react';
 
 import * as Icons from '.';
 
-const { ...icons } = Icons;
-
 const IconList = () => {
-  const iconComponents = Object.keys(icons).map((icon) => icons[icon as keyof typeof icons]);
+  const iconComponents = Object.keys(Icons).map((icon) => Icons[icon as keyof typeof Icons]);
 
   return (
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
       {iconComponents.map((IconComponent, index) => (
         <div key={index} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
           <IconComponent />
-          <div>{Object.keys(icons)[index]}</div>
+          <div>{Object.keys(Icons)[index]}</div>
         </div>
       ))}
     </div>

--- a/src/components/ui/Icons/index.stories.tsx
+++ b/src/components/ui/Icons/index.stories.tsx
@@ -1,0 +1,27 @@
+import { ComponentMeta, Story } from '@storybook/react';
+
+import * as Icons from '.';
+
+const { ...icons } = Icons;
+
+const IconList = () => {
+  const iconComponents = Object.keys(icons).map((icon) => icons[icon as keyof typeof icons]);
+
+  return (
+    <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
+      {iconComponents.map((IconComponent, index) => (
+        <div key={index} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
+          <IconComponent />
+          <div>{Object.keys(icons)[index]}</div>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default {
+  title: 'Icon',
+  component: IconList,
+} as ComponentMeta<typeof IconList>;
+
+export const _Icon: Story = () => <IconList />;


### PR DESCRIPTION
close #148 

## 概要

アイコンコンポーネントをStorybook上で一覧表示するようにしましたのでご確認お願いします

## スクリーンショット

<img width="895" alt="Storybook上にアイコンコンポーネントが一覧で表示されている画像" src="https://user-images.githubusercontent.com/30039352/235363894-e0bd8871-9721-45bf-a574-1c52aac1059d.png">
