### PR TITLE
pathpidaが生成するファイルの出力先を指定する

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "prepare": "husky install",
     "storybook": "start-storybook -p 6006 -s ./public",
     "build-storybook": "build-storybook -s public",
-    "pathpida": "pathpida --ignorePath .gitignore && prettier --write src/lib/",
+    "pathpida": "pathpida --ignorePath .gitignore --output src/lib/ && prettier --write src/lib/",
     "icons": "svgr -d src/components/ui/Icons src/assets/icons",
     "images": "node scripts/generateImages.js"
   },


### PR DESCRIPTION
close #193 

## 概要

pathpidaが生成するファイルの出力先を指定することで、src/utils/以下にファイルが生成されることを防ぎました。
（公式見た限り、`.pathignore`のような設定ファイルについての記述がないため、上記のような対応を取りました。）