### PR TITLE
StorybookのURLをPRのコメントに通知する

### DIFF
--- a/.github/workflows/notify-storybook-url.yml
+++ b/.github/workflows/notify-storybook-url.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Comment on PR
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.UYUPUN_OFFICIAL_NOTIFY_STORYBOOK_URL_PAT }}
+          github-token: ${{ secrets.NOTIFY_STORYBOOK_URL_PAT }}
           script: |
             const dir_name = process.env.DIR_NAME;
             github.rest.issues.createComment({


### PR DESCRIPTION
# 変更内容

- PRの作成時にStorybookのURLをPRのコメントとして通知するようにしました
- 通知を行うアカウントは`uyupunpopunpo`です
- `uyupunpopunpo`アカウントからPATを作成し、`uyupun/official`リポジトリのシークレットに設定することで`uyupunpopunpo`アカウントからのコメントを実現しています
- この変更により、簡単にStorybookにアクセスすることが可能になります

# 関連issue

- #210