### PR TITLE
storybook-staticをリンターやGitの管理対象に含めない

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -12,6 +12,7 @@
 
 # production
 /build
+/storybook-static
 
 # vercel
 .vercel

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ yarn-error.log*
 
 # storybook
 build-storybook.log
+storybook-static/

--- a/.ls-lint.yml
+++ b/.ls-lint.yml
@@ -25,3 +25,4 @@ ignore:
   - out
   - next-env.d.ts
   - README.md
+  - storybook-static

--- a/.prettierignore
+++ b/.prettierignore
@@ -15,6 +15,7 @@
 
 # production
 /build
+/storybook-static
 
 # vercel
 .vercel


### PR DESCRIPTION
- Storybookをビルドすると、デフォルトで`storybook-static`という名称のディレクトリが作成される
- 主にローカル環境でStorybookをビルドした際にこのディレクトリがリンターやGitの管理対象にならないようにした
- なおGitHub Actionsのワークフロー内では出力先を明示的にしていしており、`storybook-static`という名称で作成されないため影響はない