### PR TITLE
画像とフォントのパスを相対パスにする

### DIFF
--- a/src/components/base/Image/index.stories.tsx
+++ b/src/components/base/Image/index.stories.tsx
@@ -1,7 +1,6 @@
 import { ComponentMeta, Story } from '@storybook/react';
 
 import { sprinkles } from '@/styles/sprinkles.css';
-import { staticPath } from '@/utils/$path';
 
 import { Image as BaseImage, ImageSize, ImageSource } from '.';
 
@@ -12,30 +11,30 @@ export default {
 
 const sources: ImageSource[] = [
   {
-    srcset: staticPath.images.zeus.zeus_avif,
+    srcset: `./images/zeus/zeus.avif`,
     format: 'avif',
     isDesktop: true,
   },
   {
-    srcset: staticPath.images.zeus.zeus_webp,
+    srcset: `./images/zeus/zeus.webp`,
     format: 'webp',
     isDesktop: true,
   },
   {
-    srcset: staticPath.images.zeus.zeus_png,
+    srcset: `./images/zeus/zeus.png`,
     format: 'png',
     isDesktop: true,
   },
   {
-    srcset: staticPath.images.zeus.zeus_mobile_avif,
+    srcset: `./images/zeus/zeus-mobile.avif`,
     format: 'avif',
   },
   {
-    srcset: staticPath.images.zeus.zeus_mobile_webp,
+    srcset: `./images/zeus/zeus-mobile.webp`,
     format: 'webp',
   },
   {
-    srcset: staticPath.images.zeus.zeus_mobile_png,
+    srcset: `./images/zeus/zeus-mobile.png`,
     format: 'png',
   },
 ];

--- a/src/components/common/ImageLink/index.stories.tsx
+++ b/src/components/common/ImageLink/index.stories.tsx
@@ -1,7 +1,7 @@
 import { ComponentMeta, Story } from '@storybook/react';
 
 import { ImageSize, ImageSource } from '@/components/base/Image';
-import { pagesPath, staticPath } from '@/utils/$path';
+import { pagesPath } from '@/utils/$path';
 
 import { ImageLink as CommonImageLink } from '.';
 
@@ -12,30 +12,30 @@ export default {
 
 const sources: ImageSource[] = [
   {
-    srcset: staticPath.images.zeus.zeus_avif,
+    srcset: `./images/zeus/zeus.avif`,
     format: 'avif',
     isDesktop: true,
   },
   {
-    srcset: staticPath.images.zeus.zeus_webp,
+    srcset: `./images/zeus/zeus.webp`,
     format: 'webp',
     isDesktop: true,
   },
   {
-    srcset: staticPath.images.zeus.zeus_png,
+    srcset: `./images/zeus/zeus.png`,
     format: 'png',
     isDesktop: true,
   },
   {
-    srcset: staticPath.images.zeus.zeus_mobile_avif,
+    srcset: `./images/zeus/zeus-mobile.avif`,
     format: 'avif',
   },
   {
-    srcset: staticPath.images.zeus.zeus_mobile_webp,
+    srcset: `./images/zeus/zeus-mobile.webp`,
     format: 'webp',
   },
   {
-    srcset: staticPath.images.zeus.zeus_mobile_png,
+    srcset: `./images/zeus/zeus-mobile.png`,
     format: 'png',
   },
 ];

--- a/src/styles/globals.css.ts
+++ b/src/styles/globals.css.ts
@@ -3,25 +3,25 @@ import { globalFontFace, globalStyle } from '@vanilla-extract/css';
 const font = 'RictyDiminished';
 
 globalFontFace(font, {
-  src: `url('/fonts/RictyDiminished-Regular.ttf') format('truetype')`,
+  src: `url('./fonts/RictyDiminished-Regular.ttf') format('truetype')`,
   fontWeight: 'normal',
   fontStyle: 'normal',
 });
 
 globalFontFace(font, {
-  src: `url('/fonts/RictyDiminished-Bold.ttf') format('truetype')`,
+  src: `url('./fonts/RictyDiminished-Bold.ttf') format('truetype')`,
   fontWeight: 'bold',
   fontStyle: 'normal',
 });
 
 globalFontFace(font, {
-  src: `url('/fonts/RictyDiminished-Oblique.ttf') format('truetype')`,
+  src: `url('$./fonts/RictyDiminished-Oblique.ttf') format('truetype')`,
   fontWeight: 'normal',
   fontStyle: 'oblique',
 });
 
 globalFontFace(font, {
-  src: `url('/fonts/RictyDiminished-BoldOblique.ttf') format('truetype')`,
+  src: `url('./fonts/RictyDiminished-BoldOblique.ttf') format('truetype')`,
   fontWeight: 'bold',
   fontStyle: 'oblique',
 });


### PR DESCRIPTION
close #216 

## 概要

Storybook上で画像のパスを相対パスにしビルド後のindex.htmlからでもアクセスできるようにしました。また、フォントも同様に相対パスにしました。