### PR TITLE
lint-stagedで自動修正しないよう変更

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,9 +1,9 @@
 const path = require('path');
 
 const buildEslintCommand = (filenames) => {
-  return `next lint --file ${filenames
-    .map((f) => path.relative(process.cwd(), f))
-    .join(' --file ')}`;
+  const baseCommand = 'next lint --ignore-path .eslintignore --cache --cache-strategy content';
+  const lintTargets = filenames.map((f) => `--file ${path.relative(process.cwd(), f)}`).join(' ');
+  return `${baseCommand} ${lintTargets}`;
 };
 
 module.exports = {

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,13 +1,13 @@
 const path = require('path');
 
 const buildEslintCommand = (filenames) => {
-  return `next lint --fix --file ${filenames
+  return `next lint --file ${filenames
     .map((f) => path.relative(process.cwd(), f))
     .join(' --file ')}`;
 };
 
 module.exports = {
   '*.{js,jsx,ts,tsx}': [buildEslintCommand],
-  '*.{js,jsx,ts,tsx,json,html,css,yml,yaml}': 'yarn fix:prettier',
+  '*.{js,jsx,ts,tsx,json,html,css,yml,yaml}': 'yarn lint:prettier',
   '*.*': 'yarn lint:ls',
 };

--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,8 +1,9 @@
 const path = require('path');
 
 const buildEslintCommand = (filenames) => {
-  const baseCommand = 'next lint --ignore-path .eslintignore --cache --cache-strategy content';
-  const lintTargets = filenames.map((f) => `--file ${path.relative(process.cwd(), f)}`).join(' ');
+  const baseCommand =
+    'next lint --ignore-path .eslintignore --cache --cache-strategy content --file';
+  const lintTargets = filenames.map((f) => path.relative(process.cwd(), f)).join(' --file ');
   return `${baseCommand} ${lintTargets}`;
 };
 


### PR DESCRIPTION
# 修正内容

- コミット時にESLintとPrettierの自動修正をやめ、チェックするのみに変更しました
- 理由としては、自動修正したファイルをそのコミットに含めたい場合と含めたくない場合があり、そのユースケースに対応できないためです
- `yarn lint:ls`も自動修正していなかった(厳密にはそのような機能がない)ので振る舞いが統一されて良いかなと思います
- それに加えて、可能な限り`yarn lint:eslint`のオプションと合わせるようにしました
- ただし、`--max-warnings 0`を指定すると`--file`で渡したファイルが`.`始まりだと警告が出て失敗してしまうため除外しています
- `yarn lint:eslint`のようにカレントディレクトリ以下を対象にする場合は問題にならないみたいですが、`--file`で明示的に渡す場合にはこの問題が発生するようです

# 懸念点

- lint-stagedではステージングされたファイルのみを対象にチェックしています
- しかし、その後実行する`yarn fix:eslint`や`yarn fix:prettier`はカレントディレクトリ以下のファイルを対象にしています
- lint-stagedではステージングされたファイルのみを対象とするために`lintstagedrc.js`の実装が若干複雑になっていますが、結局その後にカレントディレクトリ以下のファイルを対象とした自動修正という比較的重い処理を行うのであればそこまで神経質になる必要は無いのかもしれないです
- `lintstagedrc.js`の実装が若干複雑になっている要因としては、主に`next lint`が`--file`オプションを用いてステージング対象のファイルを渡さなければならないという点にあるため、今後ESLintへの置き換えを考えても良いかもしれないです

# 関連issue

- #253