### PR TITLE
branches-ignoreの修正

### DIFF
--- a/.github/workflows/deploy-chromatic.yml
+++ b/.github/workflows/deploy-chromatic.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches-ignore:
       - main
-      - dependabot/*
+      - dependabot/**
       - gh-pages
 
 jobs:


### PR DESCRIPTION
- `dependabot/foo/bar`のようなブランチ名でChromaticのデプロイが走っていたため修正
- おそらく`/`が２つ入ると`dependabot/*`ではなく`dependabot/**`でないとignoreできない