### PR TITLE
ESLintの無視ルールの修正

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -16,3 +16,5 @@
 
 # vercel
 .vercel
+
+!.*.js


### PR DESCRIPTION
# 修正内容

- ESLintでは`.`から始まるファイル名はデフォルトでリントの対象から除外されているようです
  - e.g. `.svgrrc.js`
- `yarn lint:eslint`とした場合には特にエラーは出力されませんでした
- しかし、lint-staged経由で`yarn lint:eslint`を実行した場合に、以下のようなエラーが発生します

```bash
...

✖ yarn lint:eslint:
ESLint found too many warnings (maximum: 0).
error Command failed with exit code 1.
$ eslint --max-warnings 0 . --ignore-path .eslintignore --cache --cache-strategy content --cache-file=node_modules/.cache/eslint/.eslintcache /path/to/official/.svgrrc.js

/path/to/official/.svgrrc.js
  0:0  warning  File ignored by default.  Use a negated ignore pattern (like "--ignore-pattern '!<relative/path/to/filename>'") to override

✖ 1 problem (0 errors, 1 warning)

info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
husky - pre-commit hook exited with code 1 (error)
```

- これは`--max-warnings 0`オプションで検出されたものであるため、実際にはwarningです
- lint-stagedでのみ検出される理由としては、lint-stagedでチェックする対象として`.*.js`が含まれているのに、ESLintでは`.*.js`を無視するようになっているからなのかなと思っています
- そのため、ESLintで`.*.js`に一致するファイル名を無視しないよう修正しました