### PR TITLE
husky周りのドキュメントを改善

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -10,6 +10,15 @@ $ yarn build
 $ yarn start
 ```
 
+## Gitフック
+
+```bash
+# huskyのセットアップ
+# 通常はyarn install時に自動的に実行される
+# huskyの追加更新時にのみ実行する必要がある
+$ yarn prepare
+```
+
 ## リンター・フォーマッタ
 
 ```bash

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -16,7 +16,7 @@ $ yarn start
 # huskyのセットアップ
 # 通常はyarn install時に自動的に実行される
 # huskyの追加更新時にのみ実行する必要がある
-$ yarn prepare
+$ yarn husky
 ```
 
 ## リンター・フォーマッタ

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -13,9 +13,6 @@ $ cp .env.example .env
 # 依存パッケージのインストール
 $ yarn install
 
-# huskyのセットアップ
-$ yarn prepare
-
 # 開発用サーバの起動(http://localhost:3000)
 $ yarn dev
 ```

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "pathpida": "pathpida --enableStatic --ignorePath .pathpidaignore --output src/utils/ && prettier --write 'src/utils/$path.ts'",
     "icons": "svgr -d src/components/base/Icons src/assets/icons",
     "images": "node src/scripts/generateImages.js",
-    "lighthouse": "node src/scripts/lighthouse.js"
+    "lighthouse": "node src/scripts/lighthouse.js",
+    "husky": "husky install"
   },
   "dependencies": {
     "@headlessui/react": "^1.7.4",


### PR DESCRIPTION
- huskyのセットアップは`yarn prepare`に定義されているため、`yarn install`時に自動で実行されます
- そのため、環境構築のドキュメントからはhuskyのセットアップの項目を削除し、コマンド一覧のドキュメントに移動しました