### PR TITLE
DependabotからのPRはGitHub Actionsを実行しない

### DIFF
--- a/.github/workflows/cleanup-ghpages.yml
+++ b/.github/workflows/cleanup-ghpages.yml
@@ -8,6 +8,8 @@ jobs:
     runs-on:
       - ubuntu-latest
 
+    if: ${{ !startsWith(github.ref, "refs/heads/dependabot/") }}
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/cleanup-ghpages.yml
+++ b/.github/workflows/cleanup-ghpages.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on:
       - ubuntu-latest
 
-    if: ${{ !startsWith(github.ref, "refs/heads/dependabot/") }}
+    if: ${{ !startsWith(github.ref, 'refs/heads/dependabot/') }}
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/notify-ghpages-url.yml
+++ b/.github/workflows/notify-ghpages-url.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on:
       - ubuntu-latest
 
-    if: ${{ !startsWith(github.head_ref, "dependabot/") }}
+    if: ${{ !startsWith(github.head_ref, 'dependabot/') }}
 
     steps:
       - name: Generate directory name

--- a/.github/workflows/notify-ghpages-url.yml
+++ b/.github/workflows/notify-ghpages-url.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types:
       - opened
+    branches-ignore:
+      - dependabot/**
+      - gh-pages
 
 jobs:
   notify-ghpages-url:

--- a/.github/workflows/notify-ghpages-url.yml
+++ b/.github/workflows/notify-ghpages-url.yml
@@ -4,14 +4,13 @@ on:
   pull_request:
     types:
       - opened
-    branches-ignore:
-      - dependabot/**
-      - gh-pages
 
 jobs:
   notify-ghpages-url:
     runs-on:
       - ubuntu-latest
+
+    if: ${{ !startsWith(github.head_ref, "dependabot/") }}
 
     steps:
       - name: Generate directory name

--- a/.github/workflows/publish-ghpages.yml
+++ b/.github/workflows/publish-ghpages.yml
@@ -3,6 +3,7 @@ name: Publish GitHub Pages
 on:
   push:
     branches-ignore:
+      - dependabot/**
       - gh-pages
 
 jobs:


### PR DESCRIPTION
# 変更内容

- #257 に書いています
- 本来は #256 で検証するつもりでしたがStorybookのアプデに伴ってクローズされてしまいました
- ブランチの削除時以外の動作は確認済みです(ブランチ削除時の動作はマージ後に確認予定)