### PR TITLE
tsconfig.eslint.jsonのincludeにcjsを追加する

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,7 @@
+!.*.js
+!.*.cjs
+!.*/
+
 # dependencies
 /node_modules
 /.pnp
@@ -16,7 +20,3 @@
 
 # vercel
 .vercel
-
-!.*.js
-!.*.cjs
-!/.storybook

--- a/tsconfig.eslint.json
+++ b/tsconfig.eslint.json
@@ -1,13 +1,17 @@
 {
   "extends": "./tsconfig.json",
   "include": [
-    "next-env.d.ts",
     "**/*.ts",
     "**/*.tsx",
     "**/*.js",
     "**/*.cjs",
-    ".svgrrc.cjs",
-    ".storybook/**/*.ts",
-    ".storybook/**/*.tsx"
+    "**/.*/*.ts",
+    "**/.*/*.tsx",
+    "**/.*/*.js",
+    "**/.*/*.cjs",
+    "**/.*.ts",
+    "**/.*.tsx",
+    "**/.*.js",
+    "**/.*.cjs"
   ]
 }


### PR DESCRIPTION
## 概要

タイトル通りで isseu #15 の対応漏れがあったのでchangelog.config.cjsと.svgrrc.cjsを追加した。
以下のエラーが出ていたため
```bash
Parsing error: ESLint was configured to run on `<tsconfigRootDir>/changelog.config.cjs` using `parserOptions.project`: /official/tsconfig.eslint.json
However, that TSConfig does not include this file. Either:
- Change ESLint's list of included files to not include this file
- Change that TSConfig to include this file
- Create a new TSConfig that includes this file and include it in your parserOptions.project
See the typescript-eslint docs for more info: https://typescript-eslint.io/linting/troubleshooting#i-get-errors-telling-me-eslint-was-configured-to-run--however-that-tsconfig-does-not--none-of-those-tsconfigs-include-this-file
```