### PR TITLE
ComponentPropsとComponentPropsWithoutRefを使用する

### DIFF
--- a/src/components/base/Badge/index.tsx
+++ b/src/components/base/Badge/index.tsx
@@ -1,6 +1,6 @@
 import { styles, type BadgeColor } from './styles.css';
 
-import type { ComponentProps, FC, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
 
 type BaseProps = {
   /**
@@ -13,9 +13,9 @@ type BaseProps = {
   children: ReactNode;
 };
 
-export type BadgeProps = BaseProps & Omit<ComponentProps<'span'>, keyof BaseProps>;
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'span'>, keyof BaseProps>;
 
-const Badge: FC<BadgeProps> = ({ color, children, ...props }) => {
+const Badge: FC<Props> = ({ color, children, ...props }) => {
   return (
     <span {...props} className={styles({ color })}>
       {children}

--- a/src/components/base/Button/index.tsx
+++ b/src/components/base/Button/index.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 
 import { styles } from './styles.css';
 
-import type { ButtonHTMLAttributes, FC, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
 
 type BaseProps = {
   /**
@@ -27,10 +27,9 @@ type BaseProps = {
   children: ReactNode;
 };
 
-export type ButtonProps = BaseProps &
-  Omit<ButtonHTMLAttributes<HTMLButtonElement>, keyof BaseProps>;
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'button'>, keyof BaseProps>;
 
-const Button: FC<ButtonProps> = ({
+const Button: FC<Props> = ({
   variant = 'default',
   className,
   type = 'button',

--- a/src/components/base/Heading/index.tsx
+++ b/src/components/base/Heading/index.tsx
@@ -4,7 +4,7 @@ import { styles } from './styles.css';
 
 import type { FC, ReactNode } from 'react';
 
-export type HeadingProps = {
+type Props = {
   /**
    * 見出しのタグ
    */
@@ -15,7 +15,7 @@ export type HeadingProps = {
   children: ReactNode;
 };
 
-const Heading: FC<HeadingProps> = ({ tag = 'h1', children }) => {
+const Heading: FC<Props> = ({ tag = 'h1', children }) => {
   switch (tag) {
     case 'h1':
       return <h1 className={clsx(styles.common, styles.h1)}>{children}</h1>;

--- a/src/components/base/Image/index.stories.tsx
+++ b/src/components/base/Image/index.stories.tsx
@@ -1,8 +1,9 @@
 import { sprinkles } from '@/styles/sprinkles.css';
 
-import { Image as BaseImage, type ImageSize, type ImageSource } from '.';
+import { Image as BaseImage } from '.';
 
 import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentProps } from 'react';
 
 const meta: Meta<typeof BaseImage> = {
   title: 'Base/Image',
@@ -11,7 +12,7 @@ const meta: Meta<typeof BaseImage> = {
 export default meta;
 
 type Story = StoryObj<typeof BaseImage>;
-const sources: ImageSource[] = [
+const sources: ComponentProps<typeof BaseImage>['sources'] = [
   {
     srcset: './images/zeus/zeus.avif',
     format: 'avif',
@@ -41,11 +42,11 @@ const sources: ImageSource[] = [
   },
 ];
 const alt = 'ゼウスくん';
-const width: ImageSize = {
+const width: ComponentProps<typeof BaseImage>['width'] = {
   mobile: 200,
   desktop: 300,
 };
-const height: ImageSize = {
+const height: ComponentProps<typeof BaseImage>['height'] = {
   mobile: 276,
   desktop: 413,
 };

--- a/src/components/base/Image/index.tsx
+++ b/src/components/base/Image/index.tsx
@@ -2,18 +2,18 @@ import { breakpoint } from '@/styles/breakpoint';
 
 import type { FC } from 'react';
 
-export type ImageSource = {
+type ImageSource = {
   srcset: string;
   format: 'jpeg' | 'png' | 'webp' | 'avif';
   isDesktop?: boolean;
 };
 
-export type ImageSize = {
+type ImageSize = {
   mobile: number;
   desktop: number;
 };
 
-export type ImageProps = {
+type Props = {
   /**
    * source 要素で使用する値を持つ配列
    */
@@ -61,7 +61,7 @@ const getSource = (sources: ImageSource[]): ImageSource | null => {
   return sortedSources[0];
 };
 
-const Image: FC<ImageProps> = ({ sources, alt, className, isLazy = true, height, width }) => {
+const Image: FC<Props> = ({ sources, alt, className, isLazy = true, height, width }) => {
   const sourceForImgElement = getSource(sources);
   if (sourceForImgElement === null) return <></>;
 

--- a/src/components/base/Label/index.tsx
+++ b/src/components/base/Label/index.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 
 import { styles } from './styles.css';
 
-import type { ComponentProps, FC } from 'react';
+import type { ComponentPropsWithoutRef, FC } from 'react';
 
 type BaseProps = {
   /**
@@ -11,9 +11,9 @@ type BaseProps = {
   isRequired?: boolean;
 };
 
-export type LabelProps = BaseProps & Omit<ComponentProps<'label'>, keyof BaseProps>;
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'label'>, keyof BaseProps>;
 
-const Label: FC<LabelProps> = ({ isRequired = true, htmlFor, children }) => {
+const Label: FC<Props> = ({ isRequired = true, htmlFor, children }) => {
   return (
     <label className={clsx(styles.label, isRequired && styles.requiredMark)} htmlFor={htmlFor}>
       {children}

--- a/src/components/base/Text/index.tsx
+++ b/src/components/base/Text/index.tsx
@@ -8,7 +8,7 @@ import {
 
 import type { FC, ReactNode } from 'react';
 
-export type TextProps = {
+type Props = {
   /**
    * テキストのタグ
    */
@@ -35,7 +35,7 @@ export type TextProps = {
   children: ReactNode;
 };
 
-const Text: FC<TextProps> = ({
+const Text: FC<Props> = ({
   tag = 'span',
   size = 'md',
   fontWeight = 'normal',

--- a/src/components/base/TextLink/index.tsx
+++ b/src/components/base/TextLink/index.tsx
@@ -4,7 +4,7 @@ import { getSafeLinkRel } from '@/utils/getSafeLinkRel';
 
 import { styles } from './styles.css';
 
-import type { AnchorHTMLAttributes, FC, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
 
 type BaseProps = {
   /**
@@ -22,10 +22,9 @@ type BaseProps = {
   children: ReactNode;
 };
 
-export type TextLinkProps = BaseProps &
-  Omit<AnchorHTMLAttributes<HTMLAnchorElement>, keyof BaseProps>;
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'a'>, keyof BaseProps>;
 
-const TextLink: FC<TextLinkProps> = ({ href, children, rel, target, ...props }) => {
+const TextLink: FC<Props> = ({ href, children, rel, target, ...props }) => {
   return (
     <NextLink
       {...props}

--- a/src/components/base/Textarea/index.tsx
+++ b/src/components/base/Textarea/index.tsx
@@ -8,7 +8,7 @@ import {
 
 import { styles } from './styles.css';
 
-import type { ComponentProps, FC } from 'react';
+import type { ComponentPropsWithoutRef, FC } from 'react';
 
 type BaseProps = {
   /**
@@ -33,9 +33,9 @@ type BaseProps = {
   errors: FieldErrors<FieldValues>;
 };
 
-export type TextareaProps = BaseProps & Omit<ComponentProps<'textarea'>, keyof BaseProps>;
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'textarea'>, keyof BaseProps>;
 
-const Textarea: FC<TextareaProps> = ({ id, placeholder, register, options, errors, ...props }) => {
+const Textarea: FC<Props> = ({ id, placeholder, register, options, errors, ...props }) => {
   return (
     <textarea
       {...props}

--- a/src/components/base/Textbox/index.tsx
+++ b/src/components/base/Textbox/index.tsx
@@ -2,7 +2,7 @@ import clsx from 'clsx';
 
 import { styles } from './styles.css';
 
-import type { ComponentProps, FC } from 'react';
+import type { ComponentPropsWithoutRef, FC } from 'react';
 import type { FieldErrors, FieldValues, RegisterOptions, UseFormRegister } from 'react-hook-form';
 
 type BaseProps = {
@@ -28,9 +28,9 @@ type BaseProps = {
   errors: FieldErrors<FieldValues>;
 };
 
-export type TextboxProps = BaseProps & Omit<ComponentProps<'input'>, keyof BaseProps>;
+type Props = BaseProps & Omit<ComponentPropsWithoutRef<'input'>, keyof BaseProps>;
 
-const Textbox: FC<TextboxProps> = ({ id, placeholder, register, options, errors, ...props }) => {
+const Textbox: FC<Props> = ({ id, placeholder, register, options, errors, ...props }) => {
   return (
     <input
       {...props}

--- a/src/components/common/Accordion/index.tsx
+++ b/src/components/common/Accordion/index.tsx
@@ -7,7 +7,7 @@ import { styles } from './styles.css';
 
 import type { FC, ReactNode } from 'react';
 
-export type AccordionProps = {
+type Props = {
   /**
    * 初期描画時のアコーディオンの状態
    */
@@ -22,7 +22,7 @@ export type AccordionProps = {
   children: ReactNode;
 };
 
-const Accordion: FC<AccordionProps> = ({ isOpen, buttonText, children }) => {
+const Accordion: FC<Props> = ({ isOpen, buttonText, children }) => {
   return (
     <Disclosure defaultOpen={isOpen}>
       {({ open }) => (

--- a/src/components/common/Dialog/index.tsx
+++ b/src/components/common/Dialog/index.tsx
@@ -3,7 +3,7 @@ import { Fragment, type FC, type ReactNode } from 'react';
 
 import { styles } from './styles.css';
 
-export type DialogProps = {
+type Props = {
   /**
    * ダイアログを開いているかどうか
    */
@@ -18,7 +18,7 @@ export type DialogProps = {
   onClose: () => void;
 };
 
-const Dialog: FC<DialogProps> = ({ isOpen, children, onClose }) => {
+const Dialog: FC<Props> = ({ isOpen, children, onClose }) => {
   return (
     <Transition
       as={Fragment}

--- a/src/components/common/ImageLink/index.stories.tsx
+++ b/src/components/common/ImageLink/index.stories.tsx
@@ -2,8 +2,9 @@ import { pagesPath } from '@/utils/$path';
 
 import { ImageLink as CommonImageLink } from '.';
 
-import type { ImageSize, ImageSource } from '@/components/base/Image';
+import type { Image } from '@/components/base/Image';
 import type { Meta, StoryObj } from '@storybook/react';
+import type { ComponentProps } from 'react';
 
 const meta: Meta<typeof CommonImageLink> = {
   title: 'Common/ImageLink',
@@ -12,7 +13,7 @@ const meta: Meta<typeof CommonImageLink> = {
 export default meta;
 
 type Story = StoryObj<typeof CommonImageLink>;
-const sources: ImageSource[] = [
+const sources: ComponentProps<typeof Image>['sources'] = [
   {
     srcset: './images/zeus/zeus.avif',
     format: 'avif',
@@ -41,11 +42,11 @@ const sources: ImageSource[] = [
     format: 'png',
   },
 ];
-const width: ImageSize = {
+const width: ComponentProps<typeof Image>['width'] = {
   mobile: 200,
   desktop: 300,
 };
-const height: ImageSize = {
+const height: ComponentProps<typeof Image>['height'] = {
   mobile: 276,
   desktop: 413,
 };

--- a/src/components/common/ImageLink/index.tsx
+++ b/src/components/common/ImageLink/index.tsx
@@ -1,13 +1,13 @@
 import NextLink, { type LinkProps } from 'next/link';
 
-import { Image, type ImageProps } from '@/components/base/Image';
+import { Image } from '@/components/base/Image';
 import { getSafeLinkRel } from '@/utils/getSafeLinkRel';
 
 import { styles } from './styles.css';
 
-import type { FC, HTMLAttributeAnchorTarget, ReactNode } from 'react';
+import type { ComponentProps, FC, HTMLAttributeAnchorTarget, ReactNode } from 'react';
 
-export type ImageLinkProps = Omit<ImageProps, 'alt'> & {
+type Props = Omit<ComponentProps<typeof Image>, 'alt'> & {
   /**
    * ハイパーリンクが指す先のURL
    *
@@ -35,7 +35,7 @@ export type ImageLinkProps = Omit<ImageProps, 'alt'> & {
   children: ReactNode;
 };
 
-const ImageLink: FC<ImageLinkProps> = ({ href, target, rel, text, children, ...rest }) => {
+const ImageLink: FC<Props> = ({ href, target, rel, text, children, ...rest }) => {
   return (
     <NextLink
       className={styles.imageLink}

--- a/src/components/common/ImageLink/index.tsx
+++ b/src/components/common/ImageLink/index.tsx
@@ -7,7 +7,7 @@ import { styles } from './styles.css';
 
 import type { ComponentProps, FC, HTMLAttributeAnchorTarget, ReactNode } from 'react';
 
-type Props = Omit<ComponentProps<typeof Image>, 'alt'> & {
+type BaseProps = {
   /**
    * ハイパーリンクが指す先のURL
    *
@@ -34,6 +34,8 @@ type Props = Omit<ComponentProps<typeof Image>, 'alt'> & {
    */
   children: ReactNode;
 };
+
+type Props = BaseProps & Omit<ComponentProps<typeof Image>, keyof BaseProps | 'alt'>;
 
 const ImageLink: FC<Props> = ({ href, target, rel, text, children, ...rest }) => {
   return (


### PR DESCRIPTION
close #153 

## 概要

コンポーネント内部ではComponentPropsWithoutRefを、コンポーネントから型を生成する場合はComponentPropsを使用するように修正しました。これに伴い、各コンポーネントでexportしていた型はなくなり、かつ型の名前もコンポーネント内でしか使用されないためPropsと短くしました。
