### PR TITLE
🎨 chore: .svgrrc.cjsでリントエラーが出ていたため、restrict-template-expressionsルールをオフにする

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,14 +4,7 @@
     "node": true,
     "es2021": true
   },
-  "extends": ["standard-with-typescript", "next/core-web-vitals", "prettier"],
-  "parser": "@typescript-eslint/parser",
-  "parserOptions": {
-    "ecmaVersion": "latest",
-    "sourceType": "module",
-    "project": "./tsconfig.eslint.json",
-    "jsx": true
-  },
+  "extends": ["next/core-web-vitals", "prettier"],
   "rules": {
     "import/order": [
       "warn",
@@ -32,29 +25,38 @@
       }
     ],
     "eqeqeq": "error",
-    "@typescript-eslint/no-misused-promises": [
-      "error",
-      {
-        "checksVoidReturn": {
-          "attributes": false
-        }
-      }
-    ],
-    "@typescript-eslint/consistent-type-definitions": ["error", "type"],
     "react/jsx-sort-props": "warn"
   },
   "overrides": [
     {
-      "files": ["next-env.d.ts"],
+      "files": ["*.ts", "*.tsx"],
+      "extends": ["standard-with-typescript", "next/core-web-vitals", "prettier"],
+      "parser": "@typescript-eslint/parser",
+      "parserOptions": {
+        "ecmaVersion": "latest",
+        "sourceType": "module",
+        "project": "./tsconfig.eslint.json",
+        "jsx": true
+      },
       "rules": {
-        "@typescript-eslint/triple-slash-reference": "off"
-      }
-    },
-    {
-      "files": [".svgrrc.cjs"],
-      "rules": {
-        "@typescript-eslint/restrict-template-expressions": "off"
-      }
+        "@typescript-eslint/no-misused-promises": [
+          "error",
+          {
+            "checksVoidReturn": {
+              "attributes": false
+            }
+          }
+        ],
+        "@typescript-eslint/consistent-type-definitions": ["error", "type"]
+      },
+      "overrides": [
+        {
+          "files": ["next-env.d.ts"],
+          "rules": {
+            "@typescript-eslint/triple-slash-reference": "off"
+          }
+        }
+      ]
     }
   ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,12 @@
       "rules": {
         "@typescript-eslint/triple-slash-reference": "off"
       }
+    },
+    {
+      "files": [".svgrrc.cjs"],
+      "rules": {
+        "@typescript-eslint/restrict-template-expressions": "off"
+      }
     }
   ]
 }


### PR DESCRIPTION
## 概要

タイトル通りで、以下のリントエラーが出ていたため、`.svgrrc.cjs`でのみオフにしました。

```bash
Invalid type "any" of template literal expression.
```

エラーになっていた部分は、`${variables.componentName}: FC<IconProps>`の部分で、テンプレートリテラル内の変数がany型だとダメならしい。。。