### PR TITLE
Textコンポーネントの改修

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@headlessui/react": "^1.7.4",
     "@hookform/resolvers": "^2.9.11",
+    "@vanilla-extract/dynamic": "^2.0.3",
     "clsx": "^1.2.1",
     "next": "13.2.4",
     "react": "18.2.0",

--- a/src/components/base/Text/index.stories.tsx
+++ b/src/components/base/Text/index.stories.tsx
@@ -34,20 +34,20 @@ export const Text: Story = {
       </dd>
       <dt style={{ marginBottom: '8px' }}>Size</dt>
       <dd style={{ marginBottom: '24px' }}>
-        <BaseText size="xs" tag="p">
-          size=&quot;xs&quot;
+        <BaseText fontSize={{ mobile: 10, desktop: 12 }} tag="p">
+          {'fontSize={{ mobile: 10, desktop: 12 }}'}
         </BaseText>
-        <BaseText size="sm" tag="p">
-          size=&quot;sm&quot;
+        <BaseText fontSize={{ mobile: 12, desktop: 14 }} tag="p">
+          {'fontSize={{ mobile: 12, desktop: 14 }}'}
         </BaseText>
-        <BaseText size="md" tag="p">
-          size=&quot;md&quot;
+        <BaseText fontSize={{ mobile: 14, desktop: 16 }} tag="p">
+          {'fontSize={{ mobile: 14, desktop: 16 }}'}
         </BaseText>
-        <BaseText size="lg" tag="p">
-          size=&quot;lg&quot;
+        <BaseText fontSize={{ mobile: 16, desktop: 18 }} tag="p">
+          {'fontSize={{ mobile: 16, desktop: 18 }}'}
         </BaseText>
-        <BaseText size="xl" tag="p">
-          size=&quot;xl&quot;
+        <BaseText fontSize={{ mobile: 18, desktop: 20 }} tag="p">
+          {'fontSize={{ mobile: 18, desktop: 20 }}'}
         </BaseText>
       </dd>
       <dt style={{ marginBottom: '8px' }}>Color</dt>

--- a/src/components/base/Text/index.tsx
+++ b/src/components/base/Text/index.tsx
@@ -1,9 +1,15 @@
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import clsx from 'clsx';
+
+import { vars, type FontSize } from '@/styles/themes.css';
+
 import {
-  styles,
+  baseStyles,
+  recipeStyles,
+  themeVars,
   type TextColor,
   type TextFontStyle,
   type TextFontWeight,
-  type TextSize,
 } from './styles.css';
 
 import type { FC, ReactNode } from 'react';
@@ -16,7 +22,10 @@ type Props = {
   /**
    * テキストのサイズ
    */
-  size?: TextSize;
+  fontSize?: {
+    mobile: FontSize;
+    desktop: FontSize;
+  };
   /**
    * テキストの太さ
    */
@@ -37,14 +46,16 @@ type Props = {
 
 const Text: FC<Props> = ({
   tag = 'span',
-  size = 'md',
+  fontSize = {
+    mobile: 14,
+    desktop: 16,
+  },
   fontWeight = 'normal',
   fontStyle = 'normal',
   color = 'black',
   children,
 }) => {
-  const className = styles({
-    size,
+  const recipeClassName = recipeStyles({
     color,
     fontWeight,
     display: tag === 'span' ? 'inlineBlock' : 'block',
@@ -53,11 +64,47 @@ const Text: FC<Props> = ({
 
   switch (tag) {
     case 'span':
-      return <span className={className}>{children}</span>;
+      return (
+        <span
+          className={clsx(baseStyles, recipeClassName)}
+          style={assignInlineVars(themeVars, {
+            fontSize: {
+              mobile: vars.fontSize[fontSize.mobile],
+              desktop: vars.fontSize[fontSize.desktop],
+            },
+          })}
+        >
+          {children}
+        </span>
+      );
     case 'p':
-      return <p className={className}>{children}</p>;
+      return (
+        <p
+          className={clsx(baseStyles, recipeClassName)}
+          style={assignInlineVars(themeVars, {
+            fontSize: {
+              mobile: vars.fontSize[fontSize.mobile],
+              desktop: vars.fontSize[fontSize.desktop],
+            },
+          })}
+        >
+          {children}
+        </p>
+      );
     case 'div':
-      return <div className={className}>{children}</div>;
+      return (
+        <div
+          className={clsx(baseStyles, recipeClassName)}
+          style={assignInlineVars(themeVars, {
+            fontSize: {
+              mobile: vars.fontSize[fontSize.mobile],
+              desktop: vars.fontSize[fontSize.desktop],
+            },
+          })}
+        >
+          {children}
+        </div>
+      );
   }
 };
 

--- a/src/components/base/Text/styles.css.ts
+++ b/src/components/base/Text/styles.css.ts
@@ -1,47 +1,15 @@
+import { createThemeContract, style } from '@vanilla-extract/css';
 import { recipe } from '@vanilla-extract/recipes';
 
+import { breakpointStyle } from '@/styles/breakpoint';
 import { sprinkles } from '@/styles/sprinkles.css';
 
 import type { Color } from '@/styles/themes.css';
 
-export type TextSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export type TextFontWeight = 'normal' | 'bold';
 export type TextColor = Extract<Color, 'white' | 'black' | 'red' | 'darkGray'>;
 export type TextDisplay = 'block' | 'inlineBlock';
 export type TextFontStyle = 'normal' | 'italic';
-
-const size: { [Key in TextSize]: string } = {
-  xs: sprinkles({
-    fontSize: {
-      mobile: 8,
-      desktop: 10,
-    },
-  }),
-  sm: sprinkles({
-    fontSize: {
-      mobile: 12,
-      desktop: 14,
-    },
-  }),
-  md: sprinkles({
-    fontSize: {
-      mobile: 14,
-      desktop: 16,
-    },
-  }),
-  lg: sprinkles({
-    fontSize: {
-      mobile: 18,
-      desktop: 24,
-    },
-  }),
-  xl: sprinkles({
-    fontSize: {
-      mobile: 20,
-      desktop: 36,
-    },
-  }),
-};
 
 const fontWeight: { [Key in TextFontWeight]: string } = {
   normal: sprinkles({
@@ -85,12 +53,8 @@ const fontStyle: { [Key in TextFontStyle]: string } = {
   }),
 };
 
-const styles = recipe({
-  base: sprinkles({
-    lineHeight: 'text',
-  }),
+const recipeStyles = recipe({
   variants: {
-    size,
     fontWeight,
     color,
     display,
@@ -98,4 +62,25 @@ const styles = recipe({
   },
 });
 
-export { styles };
+const themeVars = createThemeContract({
+  fontSize: {
+    mobile: null,
+    desktop: null,
+  },
+});
+
+const baseStyles = style([
+  sprinkles({
+    lineHeight: 'text',
+  }),
+  breakpointStyle(
+    {
+      fontSize: themeVars.fontSize.mobile,
+    },
+    {
+      fontSize: themeVars.fontSize.desktop,
+    }
+  ),
+]);
+
+export { baseStyles, recipeStyles, themeVars };

--- a/src/components/base/Text/styles.css.ts
+++ b/src/components/base/Text/styles.css.ts
@@ -73,14 +73,10 @@ const baseStyles = style([
   sprinkles({
     lineHeight: 'text',
   }),
-  breakpointStyle(
-    {
-      fontSize: themeVars.fontSize.mobile,
-    },
-    {
-      fontSize: themeVars.fontSize.desktop,
-    }
-  ),
+  breakpointStyle({
+    mobileStyle: { fontSize: themeVars.fontSize.mobile },
+    desktopStyle: { fontSize: themeVars.fontSize.desktop },
+  }),
 ]);
 
 export { baseStyles, recipeStyles, themeVars };

--- a/src/components/base/Text/styles.css.ts
+++ b/src/components/base/Text/styles.css.ts
@@ -74,8 +74,8 @@ const baseStyles = style([
     lineHeight: 'text',
   }),
   breakpointStyle({
-    mobileStyle: { fontSize: themeVars.fontSize.mobile },
-    desktopStyle: { fontSize: themeVars.fontSize.desktop },
+    mobile: { fontSize: themeVars.fontSize.mobile },
+    desktop: { fontSize: themeVars.fontSize.desktop },
   }),
 ]);
 

--- a/src/styles/breakpoint.ts
+++ b/src/styles/breakpoint.ts
@@ -3,14 +3,14 @@ import { style, type StyleRule } from '@vanilla-extract/css';
 export const breakpoint = 'screen and (min-width: 768px)';
 
 type BreakpointStyleRule = {
-  mobileStyle: StyleRule;
-  desktopStyle: StyleRule;
+  mobile: StyleRule;
+  desktop: StyleRule;
 };
-export const breakpointStyle = ({ mobileStyle, desktopStyle }: BreakpointStyleRule): string => {
+export const breakpointStyle = ({ mobile, desktop }: BreakpointStyleRule): string => {
   return style({
-    ...mobileStyle,
+    ...mobile,
     '@media': {
-      'screen and (min-width: 768px)': desktopStyle,
+      'screen and (min-width: 768px)': desktop,
     },
   });
 };

--- a/src/styles/breakpoint.ts
+++ b/src/styles/breakpoint.ts
@@ -2,7 +2,11 @@ import { style, type StyleRule } from '@vanilla-extract/css';
 
 export const breakpoint = 'screen and (min-width: 768px)';
 
-export const breakpointStyle = (mobileStyle: StyleRule, desktopStyle: StyleRule): string => {
+type BreakpointStyleRule = {
+  mobileStyle: StyleRule;
+  desktopStyle: StyleRule;
+};
+export const breakpointStyle = ({ mobileStyle, desktopStyle }: BreakpointStyleRule): string => {
   return style({
     ...mobileStyle,
     '@media': {

--- a/src/styles/breakpoint.ts
+++ b/src/styles/breakpoint.ts
@@ -1,1 +1,12 @@
+import { style, type StyleRule } from '@vanilla-extract/css';
+
 export const breakpoint = 'screen and (min-width: 768px)';
+
+export const breakpointStyle = (mobileStyle: StyleRule, desktopStyle: StyleRule): string => {
+  return style({
+    ...mobileStyle,
+    '@media': {
+      'screen and (min-width: 768px)': desktopStyle,
+    },
+  });
+};

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -42,7 +42,6 @@ export const spacing = {
 } as const;
 
 export const fontSize = {
-  8: '0.5rem',
   10: '0.625rem',
   12: '0.75rem',
   14: '0.875rem',
@@ -55,6 +54,8 @@ export const fontSize = {
   48: '3rem',
   64: '4rem',
 } as const;
+
+export type FontSize = keyof typeof fontSize;
 
 export const lineHeight = {
   text: '1.8',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3895,6 +3895,13 @@
     media-query-parser "^2.0.2"
     outdent "^0.8.0"
 
+"@vanilla-extract/dynamic@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@vanilla-extract/dynamic/-/dynamic-2.0.3.tgz#44b4e018cbdfb6af3d27e73c78b38617dfe419ad"
+  integrity sha512-Rglfw2gXAYiBzAQ4jgUG7rBgE2c88e/zcG27ZVoIqMHVq56wf2C1katGMm1yFMNBgzqM7oBNYzz4YOMzznydkg==
+  dependencies:
+    "@vanilla-extract/private" "^1.0.3"
+
 "@vanilla-extract/integration@^6.0.0":
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/@vanilla-extract/integration/-/integration-6.2.1.tgz#e87849ed3d8e9ddd2703b8b8597fdbff08cf62ad"


### PR DESCRIPTION
ref: #305

## 概要

Figmaのデザイン刷新によるTextコンポーネントの改修を行いました。確認お願いします🙏

<img width="1000" alt="Storybook上でTextコンポーネントを描画している画像" src="https://github.com/uyupun/official/assets/30039352/95931e3d-875c-4035-b6ae-14ca189a85b5">

## コード解説

今まではvanilla-extractの[Recipes](https://vanilla-extract.style/documentation/packages/recipes/)機能を用いて、予め定義していたサイズ（xsなど）を使用するようにしていましたが、デザインを刷新したことによって定義していたサイズ以外の組み合わせが出てきました。そのため、[Dynamic](https://vanilla-extract.style/documentation/packages/dynamic/)機能を用いて動的にフォントサイズを変更できるようにしました。
Dynamic機能自体はstyle属性でCSS変数を定義し、その定義したCSS変数を用いてスタイリングするような形となります。

また、今までレスポンシブ対応は[Sprinkles](https://vanilla-extract.style/documentation/packages/sprinkles/)機能を通じて行っていましたが、SprinklesとDynamicは一緒に扱うことができず、やむを得ず`src/styles/breakpoint.ts`内にレスポンシブ対応を行うための関数を用意し、それを用いることでDynamic機能でもレスポンシブ対応を実現しております。