### PR TITLE
ImageコンポーネントにJSDocを追加

### DIFF
--- a/src/components/base/Image/index.tsx
+++ b/src/components/base/Image/index.tsx
@@ -31,7 +31,7 @@ type Props = {
    * ビューポート外にある画像: true
    * ビューポート内にある画像: false
    */
-  isLazy?: boolean;
+  isLazy: boolean;
   /**
    * 画像の横幅
    */
@@ -71,7 +71,7 @@ const getSource = (sources: ImageSource[]): ImageSource | null => {
  *
  * ref: https://zenn.dev/ixkaito/articles/deep-dive-into-decoding
  */
-const Image: FC<Props> = ({ sources, alt, className, isLazy = true, height, width }) => {
+const Image: FC<Props> = ({ sources, alt, className, isLazy, height, width }) => {
   const sourceForImgElement = getSource(sources);
   if (sourceForImgElement === null) return <></>;
 

--- a/src/components/base/Image/index.tsx
+++ b/src/components/base/Image/index.tsx
@@ -92,7 +92,7 @@ const Image: FC<Props> = ({ sources, alt, className, isLazy, height, width }) =>
       <img
         alt={alt}
         className={className}
-        decoding="async"
+        decoding="auto"
         height={sourceForImgElement.isDesktop === true ? height.desktop : height.mobile}
         loading={isLazy ? 'lazy' : 'eager'}
         src={sourceForImgElement.srcset}

--- a/src/components/base/Image/index.tsx
+++ b/src/components/base/Image/index.tsx
@@ -28,6 +28,8 @@ type Props = {
   className?: string;
   /**
    * 画像の読み込みを遅延させるかどうか
+   * ビューポート外にある画像: true
+   * ビューポート内にある画像: false
    */
   isLazy?: boolean;
   /**
@@ -61,6 +63,14 @@ const getSource = (sources: ImageSource[]): ImageSource | null => {
   return sortedSources[0];
 };
 
+/**
+ * ビューポートのどこで使用するかによって isLazy の値を以下のように変更する
+ * ビューポート外にある画像: true
+ * ビューポート内にある画像: false
+ * また decoding の値は常に auto とし、ブラウザに任せる
+ *
+ * ref: https://zenn.dev/ixkaito/articles/deep-dive-into-decoding
+ */
 const Image: FC<Props> = ({ sources, alt, className, isLazy = true, height, width }) => {
   const sourceForImgElement = getSource(sources);
   if (sourceForImgElement === null) return <></>;

--- a/src/components/common/ImageLink/index.stories.tsx
+++ b/src/components/common/ImageLink/index.stories.tsx
@@ -59,6 +59,7 @@ export const ImageLink: Story = {
         <CommonImageLink
           height={height}
           href={pagesPath.$url()}
+          isLazy={false}
           sources={sources}
           text="ゼウスくん"
           width={width}
@@ -71,6 +72,7 @@ export const ImageLink: Story = {
         <CommonImageLink
           height={height}
           href="https://example.com/"
+          isLazy={false}
           rel="noreferrer noopener"
           sources={sources}
           target="_blank"
@@ -85,6 +87,7 @@ export const ImageLink: Story = {
         <CommonImageLink
           height={height}
           href="https://example.com/"
+          isLazy={true}
           rel="noreferrer noopener"
           sources={sources}
           target="_blank"


### PR DESCRIPTION
close #248 

## 概要

ややこしい`loading`と`decoding`に関してJSDoc内で説明を追記しました。また、以下記事参考に`decoding`の値は`auto`としてブラウザに任せるようにし、`loading`は都度Imageコンポーネント使用側で値を設定するよう型を修正しました。

https://zenn.dev/ixkaito/articles/deep-dive-into-decoding

記事をまとめると以下の通りでした。

- 画像は基本非同期で読み込まれる
- loading="lazy"は、ビューポート外にある画像に使う
- decodingの値は"auto"としてブラウザに任せる
  - 必要に応じて`sync`と`async`を使い分けても良いが、現状このプロジェクトでは`auto`で事足りるはず