### PR TITLE
Textコンポーネントからsizeプロパティの削除

### DIFF
--- a/src/components/base/Text/index.stories.tsx
+++ b/src/components/base/Text/index.stories.tsx
@@ -32,24 +32,6 @@ export const Text: Story = {
           fontStyle=&quot;italic&quot;
         </BaseText>
       </dd>
-      <dt style={{ marginBottom: '8px' }}>Size</dt>
-      <dd style={{ marginBottom: '24px' }}>
-        <BaseText size="xs" tag="p">
-          size=&quot;xs&quot;
-        </BaseText>
-        <BaseText size="sm" tag="p">
-          size=&quot;sm&quot;
-        </BaseText>
-        <BaseText size="md" tag="p">
-          size=&quot;md&quot;
-        </BaseText>
-        <BaseText size="lg" tag="p">
-          size=&quot;lg&quot;
-        </BaseText>
-        <BaseText size="xl" tag="p">
-          size=&quot;xl&quot;
-        </BaseText>
-      </dd>
       <dt style={{ marginBottom: '8px' }}>Color</dt>
       <dd style={{ marginBottom: '24px' }}>
         <BaseText color="white" tag="p">

--- a/src/components/base/Text/index.tsx
+++ b/src/components/base/Text/index.tsx
@@ -1,10 +1,4 @@
-import {
-  styles,
-  type TextColor,
-  type TextFontStyle,
-  type TextFontWeight,
-  type TextSize,
-} from './styles.css';
+import { styles, type TextColor, type TextFontStyle, type TextFontWeight } from './styles.css';
 
 import type { FC, ReactNode } from 'react';
 
@@ -13,10 +7,6 @@ type Props = {
    * テキストのタグ
    */
   tag?: 'span' | 'p' | 'div';
-  /**
-   * テキストのサイズ
-   */
-  size?: TextSize;
   /**
    * テキストの太さ
    */
@@ -37,14 +27,12 @@ type Props = {
 
 const Text: FC<Props> = ({
   tag = 'span',
-  size = 'md',
   fontWeight = 'normal',
   fontStyle = 'normal',
   color = 'black',
   children,
 }) => {
   const className = styles({
-    size,
     color,
     fontWeight,
     display: tag === 'span' ? 'inlineBlock' : 'block',

--- a/src/components/base/Text/styles.css.ts
+++ b/src/components/base/Text/styles.css.ts
@@ -4,44 +4,10 @@ import { sprinkles } from '@/styles/sprinkles.css';
 
 import type { Color } from '@/styles/themes.css';
 
-export type TextSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl';
 export type TextFontWeight = 'normal' | 'bold';
 export type TextColor = Extract<Color, 'white' | 'black' | 'red' | 'darkGray'>;
 export type TextDisplay = 'block' | 'inlineBlock';
 export type TextFontStyle = 'normal' | 'italic';
-
-const size: { [Key in TextSize]: string } = {
-  xs: sprinkles({
-    fontSize: {
-      mobile: 8,
-      desktop: 10,
-    },
-  }),
-  sm: sprinkles({
-    fontSize: {
-      mobile: 12,
-      desktop: 14,
-    },
-  }),
-  md: sprinkles({
-    fontSize: {
-      mobile: 14,
-      desktop: 16,
-    },
-  }),
-  lg: sprinkles({
-    fontSize: {
-      mobile: 18,
-      desktop: 24,
-    },
-  }),
-  xl: sprinkles({
-    fontSize: {
-      mobile: 20,
-      desktop: 36,
-    },
-  }),
-};
 
 const fontWeight: { [Key in TextFontWeight]: string } = {
   normal: sprinkles({
@@ -88,9 +54,12 @@ const fontStyle: { [Key in TextFontStyle]: string } = {
 const styles = recipe({
   base: sprinkles({
     lineHeight: 'text',
+    fontSize: {
+      mobile: 14,
+      desktop: 16,
+    },
   }),
   variants: {
-    size,
     fontWeight,
     color,
     display,

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -42,9 +42,7 @@ export const spacing = {
 } as const;
 
 export const fontSize = {
-  8: '0.5rem',
   10: '0.625rem',
-  12: '0.75rem',
   14: '0.875rem',
   16: '1rem',
   18: '1.125rem',


### PR DESCRIPTION
ref #305 

## 概要

デザインの刷新に伴い、Textコンポーネントからsizeプロパティを削除し、PCは16px、SPは14pxに統一しました。
確認お願いします🥺

合わせて、使用しなくなったフォントサイズも削除しました。