### PR TITLE
themeで定義しているline-heightの値を修正と、それに伴う修正

### DIFF
--- a/src/components/base/Heading/styles.css.ts
+++ b/src/components/base/Heading/styles.css.ts
@@ -2,7 +2,7 @@ import { sprinkles } from '@/styles/sprinkles.css';
 
 const styles = {
   common: sprinkles({
-    lineHeight: 'heading',
+    lineHeight: 1.3,
     fontWeight: 'bold',
     color: 'black',
   }),

--- a/src/components/base/Text/styles.css.ts
+++ b/src/components/base/Text/styles.css.ts
@@ -53,7 +53,7 @@ const fontStyle: { [Key in TextFontStyle]: string } = {
 
 const styles = recipe({
   base: sprinkles({
-    lineHeight: 'text',
+    lineHeight: 1.8,
     fontSize: {
       mobile: 14,
       desktop: 16,

--- a/src/components/base/Textarea/styles.css.ts
+++ b/src/components/base/Textarea/styles.css.ts
@@ -14,7 +14,7 @@ const styles = {
         desktop: 16,
         mobile: 14,
       },
-      lineHeight: 'text',
+      lineHeight: 1.8,
       color: 'black',
       paddingX: 1,
       paddingY: 1.25,

--- a/src/components/common/Accordion/styles.css.ts
+++ b/src/components/common/Accordion/styles.css.ts
@@ -19,9 +19,9 @@ const styles = {
       outlineColor: {
         focusVisible: 'blue',
       },
+      lineHeight: 1,
     }),
     style({
-      lineHeight: 'normal',
       backgroundColor: 'transparent',
       cursor: 'pointer',
       padding: 0,

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -55,8 +55,9 @@ export const fontSize = {
 } as const;
 
 export const lineHeight = {
-  text: '1.8',
-  heading: '1.3',
+  1: '1',
+  1.3: '1.3',
+  1.8: '1.8',
 } as const;
 
 /**


### PR DESCRIPTION
close #311 

## 概要

`line-height`の値に1を追加し（ボタン等で使用する）、またkeyは数値に変更し扱いやすいようにしました。
上記に伴い、各コンポーネントで使用していた`line-height`も修正しました。