### PR TITLE
Badgeコンポーネントの修正とTechnologyBadgeコンポーネントの作成

### DIFF
--- a/src/components/base/Badge/index.stories.tsx
+++ b/src/components/base/Badge/index.stories.tsx
@@ -10,12 +10,5 @@ export default meta;
 
 type Story = StoryObj<typeof BaseBadge>;
 export const Badge: Story = {
-  render: () => (
-    <dl>
-      <dt style={{ marginBottom: '8px' }}>color=&quot;blue&quot;</dt>
-      <dd style={{ marginBottom: '24px' }}>
-        <BaseBadge color="blue">Badge</BaseBadge>
-      </dd>
-    </dl>
-  ),
+  render: () => <BaseBadge>Badge</BaseBadge>,
 };

--- a/src/components/base/Badge/index.tsx
+++ b/src/components/base/Badge/index.tsx
@@ -1,12 +1,10 @@
-import { styles, type BadgeColor } from './styles.css';
+import clsx from 'clsx';
+
+import { styles } from './styles.css';
 
 import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
 
 type BaseProps = {
-  /**
-   * バッジのカラー
-   */
-  color: BadgeColor;
   /**
    * バッジのコンテンツ
    */
@@ -15,9 +13,9 @@ type BaseProps = {
 
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'span'>, keyof BaseProps>;
 
-const Badge: FC<Props> = ({ color, children, ...props }) => {
+const Badge: FC<Props> = ({ children, className, ...props }) => {
   return (
-    <span {...props} className={styles({ color })}>
+    <span {...props} className={clsx(styles.badge, className)}>
       {children}
     </span>
   );

--- a/src/components/base/Badge/styles.css.ts
+++ b/src/components/base/Badge/styles.css.ts
@@ -1,37 +1,29 @@
 import { style } from '@vanilla-extract/css';
-import { recipe } from '@vanilla-extract/recipes';
 
 import { sprinkles } from '@/styles/sprinkles.css';
+import { vars } from '@/styles/themes.css';
 
-import type { Color } from '@/styles/themes.css';
-
-export type BadgeColor = Extract<Color, 'blue'>;
-
-const color: { [Key in BadgeColor]: string } = {
-  blue: sprinkles({
-    color: 'white',
-    backgroundColor: 'blue',
-  }),
-};
-
-const styles = recipe({
-  base: style([
+const styles = {
+  badge: style([
     sprinkles({
       display: 'inline-block',
       fontSize: {
         mobile: 14,
         desktop: 16,
       },
+      lineHeight: 1,
+      color: 'white',
+      backgroundColor: 'black',
       paddingX: 1,
       paddingY: 0.5,
     }),
     {
+      borderWidth: '1px',
+      borderStyle: 'solid',
+      borderColor: vars.colors.white,
       borderRadius: '16px',
     },
   ]),
-  variants: {
-    color,
-  },
-});
+};
 
 export { styles };

--- a/src/components/case/TechnologyBadge/constant.ts
+++ b/src/components/case/TechnologyBadge/constant.ts
@@ -1,0 +1,14 @@
+const technologies = {
+  expo: {
+    name: 'Expo',
+    color: '#000000',
+  },
+  fastApi: {
+    name: 'FastAPI',
+    color: '#009485',
+  },
+} as const;
+
+type Technology = keyof typeof technologies;
+
+export { technologies, type Technology };

--- a/src/components/case/TechnologyBadge/index.stories.tsx
+++ b/src/components/case/TechnologyBadge/index.stories.tsx
@@ -1,0 +1,25 @@
+import { TechnologyBadge as CaseTechnologyBadge } from '.';
+
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof CaseTechnologyBadge> = {
+  title: 'Case/TechnologyBadge',
+  component: CaseTechnologyBadge,
+};
+export default meta;
+
+type Story = StoryObj<typeof CaseTechnologyBadge>;
+export const TechnologyBadge: Story = {
+  render: () => (
+    <dl>
+      <dt style={{ marginBottom: '8px' }}>label=&quot;expo&quot;</dt>
+      <dd style={{ marginBottom: '24px' }}>
+        <CaseTechnologyBadge label="expo" />
+      </dd>
+      <dt style={{ marginBottom: '8px' }}>label=&quot;fastApi&quot;</dt>
+      <dd style={{ marginBottom: '24px' }}>
+        <CaseTechnologyBadge label="fastApi" />
+      </dd>
+    </dl>
+  ),
+};

--- a/src/components/case/TechnologyBadge/index.tsx
+++ b/src/components/case/TechnologyBadge/index.tsx
@@ -1,0 +1,19 @@
+import { Badge } from '@/components/base/Badge';
+
+import { technologies, type Technology } from './constant';
+import { styles } from './styles.css';
+
+import type { FC } from 'react';
+
+type Props = {
+  /**
+   * バッジのラベル
+   */
+  label: Technology;
+};
+
+const TechnologyBadge: FC<Props> = ({ label }) => {
+  return <Badge className={styles({ label })}>{technologies[label].name}</Badge>;
+};
+
+export { TechnologyBadge };

--- a/src/components/case/TechnologyBadge/styles.css.ts
+++ b/src/components/case/TechnologyBadge/styles.css.ts
@@ -1,0 +1,25 @@
+import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
+
+import { vars } from '@/styles/themes.css';
+
+import { technologies, type Technology } from './constant';
+
+const label: { [Key in Technology]: string } = {
+  expo: style({
+    color: vars.colors.white,
+    backgroundColor: technologies.expo.color,
+  }),
+  fastApi: style({
+    color: vars.colors.white,
+    backgroundColor: technologies.fastApi.color,
+  }),
+};
+
+const styles = recipe({
+  variants: {
+    label,
+  },
+});
+
+export { styles };


### PR DESCRIPTION
ref #305 

## 概要

Figamのデザインを新しくしたため、それに伴ってBadgeコンポーネントを修正しました。また、Badgeコンポーネントは汎用的に使用できる形とし、新しく技術の表示に特化したTechnologyBadgeコンポーネントを作成しました。
確認お願いします🙏

## スクリーンショット

### Badge

<img width="1000" alt="Storybook上でBadgeコンポーネントが表示されている" src="https://github.com/uyupun/official/assets/30039352/0c7fba58-66fd-4ea9-853c-1d346257bf86">

### TechnologyBadge

<img width="1000" alt="Storybook上でTechnologyBadgeコンポーネントが表示されている" src="https://github.com/uyupun/official/assets/30039352/b649380f-9231-4433-b1ed-1d81c1258201">
