### PR TITLE
Headingコンポーネントのカラーを修正

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -19,10 +19,11 @@ export const parameters: Parameters = {
     ),
   },
   backgrounds: {
+    default: 'gradientBlue',
     values: [
       {
-        name: 'blue',
-        value: colors.blue,
+        name: 'gradientBlue',
+        value: colors.gradientBlue,
       },
     ],
   },

--- a/src/components/base/Heading/styles.css.ts
+++ b/src/components/base/Heading/styles.css.ts
@@ -4,7 +4,7 @@ const styles = {
   common: sprinkles({
     lineHeight: 1.3,
     fontWeight: 'bold',
-    color: 'black',
+    color: 'white',
   }),
   h1: sprinkles({
     fontSize: {

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -12,6 +12,7 @@ export const colors = {
   purple: '#B01CF6',
   red: '#E6002F',
   lightRed: '#FBD4D4',
+  gradientBlue: 'linear-gradient(#0078B7, #001E43)',
 } as const;
 
 export type Color = keyof typeof colors;


### PR DESCRIPTION
ref #305 

## 概要

特に変更点はなかったが、カラーだけ変更したので確認お願いします（背景をblueにすると見えます！）

## スクリーンショット

<img width="1503" alt="Storybook上でHeadingコンポーネントが表示されている" src="https://github.com/uyupun/official/assets/30039352/02096c97-6053-4b1c-a0a0-4ff99e26853e">
