### PR TITLE
Labelコンポーネントの修正

### DIFF
--- a/src/components/base/Label/index.stories.tsx
+++ b/src/components/base/Label/index.stories.tsx
@@ -12,13 +12,23 @@ type Story = StoryObj<typeof BaseLabel>;
 export const Label: Story = {
   render: () => (
     <dl>
-      <dt style={{ marginBottom: '8px' }}>Default</dt>
-      <dd style={{ marginBottom: '24px' }}>
-        <BaseLabel>Required label</BaseLabel>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>Default</dt>
+      <dd style={{ color: 'white', marginBottom: '24px' }}>
+        <BaseLabel text="Required label" />
       </dd>
-      <dt style={{ marginBottom: '8px' }}>Not required</dt>
-      <dd style={{ marginBottom: '24px' }}>
-        <BaseLabel isRequired={false}>Not required label</BaseLabel>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>Not required</dt>
+      <dd style={{ color: 'white', marginBottom: '24px' }}>
+        <BaseLabel isRequired={false} text="Not required label" />
+      </dd>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>Form</dt>
+      <dd style={{ color: 'white', marginBottom: '24px' }}>
+        <BaseLabel text="textbox 1">
+          <input aria-required style={{ marginLeft: '16px' }} type="text" />
+        </BaseLabel>
+        <div style={{ display: 'flex', flexDirection: 'column', marginTop: '16px' }}>
+          <BaseLabel htmlFor="textbox2" text="textbox 2" />
+          <input aria-required id="textbox2" type="text" />
+        </div>
       </dd>
     </dl>
   ),

--- a/src/components/base/Label/index.stories.tsx
+++ b/src/components/base/Label/index.stories.tsx
@@ -22,12 +22,9 @@ export const Label: Story = {
       </dd>
       <dt style={{ color: 'white', marginBottom: '8px' }}>Form</dt>
       <dd style={{ color: 'white', marginBottom: '24px' }}>
-        <BaseLabel text="textbox 1">
-          <input aria-required style={{ marginLeft: '16px' }} type="text" />
-        </BaseLabel>
-        <div style={{ display: 'flex', flexDirection: 'column', marginTop: '16px' }}>
-          <BaseLabel htmlFor="textbox2" text="textbox 2" />
-          <input aria-required id="textbox2" type="text" />
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <BaseLabel htmlFor="textbox" text="textbox" />
+          <input aria-required id="textbox" type="text" />
         </div>
       </dd>
     </dl>

--- a/src/components/base/Label/index.tsx
+++ b/src/components/base/Label/index.tsx
@@ -6,6 +6,10 @@ import type { ComponentPropsWithoutRef, FC } from 'react';
 
 type BaseProps = {
   /**
+   * ラベルのテキスト
+   */
+  text?: string;
+  /**
    * 必須かどうか
    */
   isRequired?: boolean;
@@ -13,9 +17,15 @@ type BaseProps = {
 
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'label'>, keyof BaseProps>;
 
-const Label: FC<Props> = ({ isRequired = true, htmlFor, children }) => {
+const Label: FC<Props> = ({ text, isRequired = true, className, children, ...props }) => {
   return (
-    <label className={clsx(styles.label, isRequired && styles.requiredMark)} htmlFor={htmlFor}>
+    <label className={clsx(styles.label, className)} {...props}>
+      {text}
+      {isRequired && (
+        <span aria-hidden className={styles.requiredMark}>
+          *
+        </span>
+      )}
       {children}
     </label>
   );

--- a/src/components/base/Label/index.tsx
+++ b/src/components/base/Label/index.tsx
@@ -8,7 +8,7 @@ type BaseProps = {
   /**
    * ラベルのテキスト
    */
-  text?: string;
+  text: string;
   /**
    * 必須かどうか
    */
@@ -17,7 +17,7 @@ type BaseProps = {
 
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'label'>, keyof BaseProps>;
 
-const Label: FC<Props> = ({ text, isRequired = true, className, children, ...props }) => {
+const Label: FC<Props> = ({ text, isRequired = true, className, ...props }) => {
   return (
     <label className={clsx(styles.label, className)} {...props}>
       {text}
@@ -26,7 +26,6 @@ const Label: FC<Props> = ({ text, isRequired = true, className, children, ...pro
           *
         </span>
       )}
-      {children}
     </label>
   );
 };

--- a/src/components/base/Label/styles.css.ts
+++ b/src/components/base/Label/styles.css.ts
@@ -1,25 +1,18 @@
-import { style } from '@vanilla-extract/css';
-
 import { sprinkles } from '@/styles/sprinkles.css';
-import { vars } from '@/styles/themes.css';
 
 const styles = {
   label: sprinkles({
-    fontSize: {
-      mobile: 14,
-      desktop: 16,
-    },
-    color: 'black',
+    display: 'inline-flex',
+    fontSize: 16,
+    color: 'white',
+    lineHeight: 1,
   }),
-  requiredMark: style({
-    position: 'relative',
-    '::after': {
-      content: '*',
-      position: 'absolute',
-      top: '-75%',
-      color: vars.colors.red,
-      paddingLeft: vars.spacing['0.5'],
-    },
+  requiredMark: sprinkles({
+    display: 'inline-block',
+    fontSize: 14,
+    fontWeight: 'bold',
+    color: 'red',
+    paddingLeft: 0.5,
   }),
 };
 

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -10,7 +10,7 @@ export const colors = {
   lightBlue: '#0080FF',
   hoverBlue: 'rgba(30, 26, 222, 0.8)',
   purple: '#B01CF6',
-  red: '#E6002F',
+  red: '#FF4747',
   lightRed: '#FBD4D4',
 } as const;
 


### PR DESCRIPTION
ref #305 

## 概要

デザイン修正に伴い、Labelコンポーネントを修正しました。
デザイン上Labelでinputをラップするような構造にはならないため、childrenは削除しました🙏
確認お願いします！

## その他

PR #337 マージ後にデフォルトで背景色が付くようになります

## スクリーンショット

<img width="1124" alt="Storybook上にLabelコンポーネントが表示されている" src="https://github.com/uyupun/official/assets/30039352/75de1909-cf5b-4774-969a-3605bbdd8a8d">
