### PR TITLE
テキストボックスのデザイン修正

### DIFF
--- a/src/components/base/Textbox/index.stories.tsx
+++ b/src/components/base/Textbox/index.stories.tsx
@@ -32,7 +32,9 @@ export const Textbox: Story = {
       <form onSubmit={handleSubmit(action('handleSubmit'))}>
         <dl>
           <dt style={{ marginBottom: '8px' }}>
-            <label htmlFor="title">Title</label>
+            <label htmlFor="title" style={{ color: 'white' }}>
+              Title
+            </label>
           </dt>
           <dd style={{ marginBottom: '24px' }}>
             <BaseTextbox errors={errors} id="title" register={register} />

--- a/src/components/base/Textbox/styles.css.ts
+++ b/src/components/base/Textbox/styles.css.ts
@@ -36,6 +36,9 @@ const styles = {
   error: sprinkles({
     color: 'red',
     borderColor: 'red',
+    outlineColor: {
+      focusVisible: 'red',
+    },
   }),
 };
 

--- a/src/components/base/Textbox/styles.css.ts
+++ b/src/components/base/Textbox/styles.css.ts
@@ -5,31 +5,37 @@ import { sprinkles } from '@/styles/sprinkles.css';
 const styles = {
   textbox: style([
     sprinkles({
-      height: {
-        desktop: 40,
-        mobile: 36,
-      },
-      fontSize: {
-        desktop: 16,
-        mobile: 14,
-      },
-      color: 'black',
+      height: 40,
+      fontSize: 16,
+      lineHeight: 1,
+      color: 'white',
       paddingX: 1,
-      borderColor: {
-        default: 'gray',
-        focusVisible: 'blue',
+      borderColor: 'white',
+      outlineWidth: {
+        focusVisible: 2,
+      },
+      outlineStyle: {
+        focusVisible: 'solid',
+      },
+      outlineColor: {
+        focusVisible: 'white',
+      },
+      outlineOffset: {
+        focusVisible: -1,
       },
     }),
     {
       width: '100%',
-      borderWidth: '1px',
+      backgroundColor: 'transparent',
+      borderWidth: 1,
       borderStyle: 'solid',
-      borderRadius: '5px',
+      borderRadius: 5,
+      outline: 'none',
     },
   ]),
   error: sprinkles({
+    color: 'red',
     borderColor: 'red',
-    backgroundColor: 'lightRed',
   }),
 };
 

--- a/src/styles/sprinkles.css.ts
+++ b/src/styles/sprinkles.css.ts
@@ -73,7 +73,10 @@ const selectorProperties = defineProperties({
   defaultCondition: 'default',
   properties: {
     borderColor: vars.colors,
+    outlineWidth: [2],
+    outlineStyle: ['solid'],
     outlineColor: vars.colors,
+    outlineOffset: [-1],
     opacity: [0.3, 0.8, 1],
     cursor: ['pointer', 'not-allowed'],
   },


### PR DESCRIPTION
ref #305 

## 概要

Figmaのデザイン変更に伴い、テキストボックスのデザインを修正しましたので確認お願いします

## スクリーンショット

### デフォルト

<img width="658" alt="Storybook上に表示されたテキストボックスの画像" src="https://github.com/uyupun/official/assets/30039352/9ecf824f-4b23-41be-b7c3-a8211ecb6764">

### フォーカス

<img width="658" alt="Storybook上に表示されたテキストボックスの画像。フォーカスが当たっている。" src="https://github.com/uyupun/official/assets/30039352/a946acc5-b722-4e1d-bf88-cc8089e8fc4d">

### エラー

<img width="657" alt="Storybook上に表示されたテキストボックスの画像。文字数超過のエラーとなっている。" src="https://github.com/uyupun/official/assets/30039352/600f880c-f27a-4683-8b8e-372d0a9d446d">

