### PR TITLE
テキストエリアのデザインを修正

### DIFF
--- a/src/components/base/Textarea/index.stories.tsx
+++ b/src/components/base/Textarea/index.stories.tsx
@@ -32,7 +32,9 @@ export const Textarea: Story = {
       <form onSubmit={handleSubmit(action('handleSubmit'))}>
         <dl>
           <dt style={{ marginBottom: '8px' }}>
-            <label htmlFor="description">Description</label>
+            <label htmlFor="description" style={{ color: 'white' }}>
+              Description
+            </label>
           </dt>
           <dd style={{ marginBottom: '24px' }}>
             <BaseTextarea errors={errors} id="description" register={register} />

--- a/src/components/base/Textarea/styles.css.ts
+++ b/src/components/base/Textarea/styles.css.ts
@@ -42,6 +42,9 @@ const styles = {
   error: sprinkles({
     color: 'red',
     borderColor: 'red',
+    outlineColor: {
+      focusVisible: 'red',
+    },
   }),
 };
 

--- a/src/components/base/Textarea/styles.css.ts
+++ b/src/components/base/Textarea/styles.css.ts
@@ -10,30 +10,38 @@ const styles = {
         mobile: 200,
       },
       minHeight: 100,
-      fontSize: {
-        desktop: 16,
-        mobile: 14,
-      },
+      fontSize: 16,
       lineHeight: 1.8,
-      color: 'black',
+      color: 'white',
       paddingX: 1,
       paddingY: 1.25,
-      borderColor: {
-        default: 'gray',
-        focusVisible: 'blue',
+      borderColor: 'white',
+      outlineWidth: {
+        focusVisible: 2,
+      },
+      outlineStyle: {
+        focusVisible: 'solid',
+      },
+      outlineColor: {
+        focusVisible: 'white',
+      },
+      outlineOffset: {
+        focusVisible: -1,
       },
     }),
     {
       width: '100%',
-      borderWidth: '1px',
+      backgroundColor: 'transparent',
+      borderWidth: 1,
       borderStyle: 'solid',
-      borderRadius: '5px',
+      borderRadius: 5,
       resize: 'vertical',
+      outline: 'none',
     },
   ]),
   error: sprinkles({
+    color: 'red',
     borderColor: 'red',
-    backgroundColor: 'lightRed',
   }),
 };
 


### PR DESCRIPTION
ref #305 

## 概要

Figmaのデザイン変更に伴い、テキストエリアのデザインを修正しましたので確認お願いします

## スクリーンショット

### デフォルト

<img width="754" alt="Storybook上に表示されたテキストエリアの画像" src="https://github.com/uyupun/official/assets/30039352/e668ee93-fe29-4edb-adf2-9166a81de8ef">

### フォーカス

<img width="750" alt="Storybook上に表示されたテキストエリアの画像。フォーカスが当たっている。" src="https://github.com/uyupun/official/assets/30039352/5f805ea4-5d19-43ed-a848-26a45ddb4f80">

### エラー

<img width="751" alt="Storybook上に表示されたテキストエリアの画像。文字数超過のエラーデザインが適用されている。" src="https://github.com/uyupun/official/assets/30039352/172640af-7878-4306-8d1e-73a0b325e889">

## その他

PR #340 がマージ後にDraftを解除する