### PR TITLE
テキストリンクのデザイン修正

### DIFF
--- a/src/components/base/TextLink/index.stories.tsx
+++ b/src/components/base/TextLink/index.stories.tsx
@@ -24,10 +24,10 @@ export const TextLink: Story = {
           target=&quot;_blank&quot; TextLink
         </BaseTextLink>
       </dd>
-      <dt style={{ color: 'white' }}>isLarge=&quot;true&quot;</dt>
+      <dt style={{ color: 'white' }}>size=&quot;lg&quot;</dt>
       <dd style={{ marginBottom: '16px' }}>
-        <BaseTextLink href={pagesPath.$url()} isLarge={true}>
-          isLarge=&quot;true&quot; TextLink
+        <BaseTextLink href={pagesPath.$url()} size={'lg'}>
+          size=&quot;lg&quot; TextLink
         </BaseTextLink>
       </dd>
     </dl>

--- a/src/components/base/TextLink/index.stories.tsx
+++ b/src/components/base/TextLink/index.stories.tsx
@@ -24,6 +24,12 @@ export const TextLink: Story = {
           target=&quot;_blank&quot; TextLink
         </BaseTextLink>
       </dd>
+      <dt style={{ color: 'white' }}>isLarge=&quot;true&quot;</dt>
+      <dd style={{ marginBottom: '16px' }}>
+        <BaseTextLink href={pagesPath.$url()} isLarge={true}>
+          isLarge=&quot;true&quot; TextLink
+        </BaseTextLink>
+      </dd>
     </dl>
   ),
 };

--- a/src/components/base/TextLink/index.stories.tsx
+++ b/src/components/base/TextLink/index.stories.tsx
@@ -14,11 +14,11 @@ type Story = StoryObj<typeof BaseTextLink>;
 export const TextLink: Story = {
   render: () => (
     <dl>
-      <dt>Default</dt>
+      <dt style={{ color: 'white' }}>Default</dt>
       <dd style={{ marginBottom: '16px' }}>
         <BaseTextLink href={pagesPath.$url()}>Default TextLink</BaseTextLink>
       </dd>
-      <dt>target=&quot;_blank&quot;</dt>
+      <dt style={{ color: 'white' }}>target=&quot;_blank&quot;</dt>
       <dd style={{ marginBottom: '16px' }}>
         <BaseTextLink href={pagesPath.$url()} target={'_blank'}>
           target=&quot;_blank&quot; TextLink

--- a/src/components/base/TextLink/index.tsx
+++ b/src/components/base/TextLink/index.tsx
@@ -1,9 +1,8 @@
-import clsx from 'clsx';
 import NextLink, { type LinkProps } from 'next/link';
 
 import { getSafeLinkRel } from '@/utils/getSafeLinkRel';
 
-import { styles } from './styles.css';
+import { styles, type Size } from './styles.css';
 
 import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
 
@@ -18,9 +17,9 @@ type BaseProps = {
    */
   href: LinkProps['href'];
   /**
-   * 文字サイズを大きくするかどうか
+   * 文字のサイズ
    */
-  isLarge?: boolean;
+  size?: Size;
   /**
    * リンクのコンテンツ
    */
@@ -29,11 +28,11 @@ type BaseProps = {
 
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'a'>, keyof BaseProps>;
 
-const TextLink: FC<Props> = ({ href, isLarge = false, children, rel, target, ...props }) => {
+const TextLink: FC<Props> = ({ href, size = 'md', children, rel, target, ...props }) => {
   return (
     <NextLink
       {...props}
-      className={clsx(styles.link, isLarge && styles.large)}
+      className={styles({ size })}
       href={href}
       rel={getSafeLinkRel(rel, target)}
       target={target}

--- a/src/components/base/TextLink/index.tsx
+++ b/src/components/base/TextLink/index.tsx
@@ -1,3 +1,4 @@
+import clsx from 'clsx';
 import NextLink, { type LinkProps } from 'next/link';
 
 import { getSafeLinkRel } from '@/utils/getSafeLinkRel';
@@ -17,6 +18,10 @@ type BaseProps = {
    */
   href: LinkProps['href'];
   /**
+   * 文字サイズを大きくするかどうか
+   */
+  isLarge?: boolean;
+  /**
    * リンクのコンテンツ
    */
   children: ReactNode;
@@ -24,11 +29,11 @@ type BaseProps = {
 
 type Props = BaseProps & Omit<ComponentPropsWithoutRef<'a'>, keyof BaseProps>;
 
-const TextLink: FC<Props> = ({ href, children, rel, target, ...props }) => {
+const TextLink: FC<Props> = ({ href, isLarge = false, children, rel, target, ...props }) => {
   return (
     <NextLink
       {...props}
-      className={styles.link}
+      className={clsx(styles.link, isLarge && styles.large)}
       href={href}
       rel={getSafeLinkRel(rel, target)}
       target={target}

--- a/src/components/base/TextLink/styles.css.ts
+++ b/src/components/base/TextLink/styles.css.ts
@@ -10,10 +10,7 @@ const styles = {
         mobile: 14,
         desktop: 16,
       },
-      color: {
-        default: 'lightBlue',
-        visited: 'purple',
-      },
+      color: 'lightBlue',
       outlineColor: {
         focusVisible: 'lightBlue',
       },

--- a/src/components/base/TextLink/styles.css.ts
+++ b/src/components/base/TextLink/styles.css.ts
@@ -1,15 +1,29 @@
 import { style } from '@vanilla-extract/css';
+import { recipe } from '@vanilla-extract/recipes';
 
 import { sprinkles } from '@/styles/sprinkles.css';
 
-const styles = {
-  link: style([
+type Size = 'md' | 'lg';
+
+const size: { [Key in Size]: string } = {
+  md: sprinkles({
+    fontSize: {
+      mobile: 14,
+      desktop: 16,
+    },
+  }),
+  lg: sprinkles({
+    fontSize: {
+      mobile: 24,
+      desktop: 36,
+    },
+  }),
+};
+
+const styles = recipe({
+  base: style([
     sprinkles({
       display: 'inline-block',
-      fontSize: {
-        mobile: 14,
-        desktop: 16,
-      },
       lineHeight: 1,
       color: 'white',
       outlineWidth: {
@@ -29,14 +43,9 @@ const styles = {
       textDecoration: 'underline',
     },
   ]),
-  large: sprinkles({
-    fontSize: {
-      mobile: 24,
-      desktop: 36,
-    },
-    fontWeight: 'bold',
-    lineHeight: 1.3,
-  }),
-};
+  variants: {
+    size,
+  },
+});
 
-export { styles };
+export { styles, type Size };

--- a/src/components/base/TextLink/styles.css.ts
+++ b/src/components/base/TextLink/styles.css.ts
@@ -10,13 +10,16 @@ const styles = {
         mobile: 14,
         desktop: 16,
       },
-      color: 'lightBlue',
-      outlineColor: {
-        focusVisible: 'lightBlue',
+      lineHeight: 1,
+      color: 'white',
+      outlineWidth: {
+        focusVisible: 1,
       },
-      opacity: {
-        focusVisible: 0.8,
-        hover: 0.8,
+      outlineStyle: {
+        focusVisible: 'solid',
+      },
+      outlineColor: {
+        focusVisible: 'white',
       },
       cursor: {
         default: 'pointer',

--- a/src/components/base/TextLink/styles.css.ts
+++ b/src/components/base/TextLink/styles.css.ts
@@ -29,6 +29,14 @@ const styles = {
       textDecoration: 'underline',
     },
   ]),
+  large: sprinkles({
+    fontSize: {
+      mobile: 24,
+      desktop: 36,
+    },
+    fontWeight: 'bold',
+    lineHeight: 1.3,
+  }),
 };
 
 export { styles };

--- a/src/components/common/ImageLink/styles.css.ts
+++ b/src/components/common/ImageLink/styles.css.ts
@@ -68,10 +68,7 @@ const styles = {
       fontSize: {
         mobile: 18,
       },
-      color: {
-        default: 'lightBlue',
-        visited: 'purple',
-      },
+      color: 'lightBlue',
       marginTop: {
         mobile: 1,
       },

--- a/src/styles/sprinkles.css.ts
+++ b/src/styles/sprinkles.css.ts
@@ -44,18 +44,6 @@ const responsiveProperties = defineProperties({
   },
 });
 
-const colorProperties = defineProperties({
-  conditions: {
-    default: {},
-    visited: { selector: '&:visited' },
-  },
-  defaultCondition: 'default',
-  properties: {
-    color: vars.colors,
-    backgroundColor: vars.colors,
-  },
-});
-
 const lineHeightProperties = defineProperties({
   properties: {
     lineHeight: vars.lineHeight,
@@ -72,8 +60,10 @@ const selectorProperties = defineProperties({
   },
   defaultCondition: 'default',
   properties: {
+    color: vars.colors,
+    backgroundColor: vars.colors,
     borderColor: vars.colors,
-    outlineWidth: [2],
+    outlineWidth: [1, 2],
     outlineStyle: ['solid'],
     outlineColor: vars.colors,
     outlineOffset: [-1],
@@ -91,7 +81,6 @@ const fontProperties = defineProperties({
 
 export const sprinkles = createSprinkles(
   responsiveProperties,
-  colorProperties,
   lineHeightProperties,
   fontProperties,
   selectorProperties


### PR DESCRIPTION
ref #305 

## 概要

Figmaのデザイン変更に伴い、テキストリンクのデザインを修正しましたので確認お願いします

## スクリーンショット

### デフォルト

<img width="518" alt="Storybook上に表示されたテキストリンクコンポーネントの画像" src="https://github.com/uyupun/official/assets/30039352/001bbf2f-cf2e-439b-947c-f8d07a362440">

### フォーカス

<img width="509" alt="Storybook上に表示されたテキストリンクコンポーネントの画像。3つあるうちの1つにフォーカスが当たっている。" src="https://github.com/uyupun/official/assets/30039352/695b194c-f945-419b-9609-8eca615ae019">

## その他

PR #340 マージ後にDraftを解除します