### PR TITLE
デフォルトのカラーを白にする

### DIFF
--- a/.svgrrc.cjs
+++ b/.svgrrc.cjs
@@ -2,7 +2,7 @@ module.exports = {
   typescript: true,
   filenameCase: 'camel',
   svgProps: {
-    fill: '{fill !== undefined ? colors[fill] : colors.black}',
+    fill: '{fill !== undefined ? colors[fill] : colors.white}',
     stroke: '{stroke}',
     'aria-hidden': true,
   },

--- a/src/components/base/Badge/styles.css.ts
+++ b/src/components/base/Badge/styles.css.ts
@@ -13,7 +13,6 @@ const styles = {
       },
       lineHeight: 1,
       color: 'white',
-      backgroundColor: 'black',
       paddingX: 1,
       paddingY: 0.5,
     }),

--- a/src/components/base/Button/index.stories.tsx
+++ b/src/components/base/Button/index.stories.tsx
@@ -14,13 +14,13 @@ type Story = StoryObj<typeof BaseButton>;
 export const Button: Story = {
   render: () => (
     <dl>
-      <dt style={{ marginBottom: '8px' }}>Default</dt>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>Default</dt>
       <dd style={{ marginBottom: '24px' }}>
         <BaseButton onClick={action('clicked')} type="button">
           Default Button
         </BaseButton>
       </dd>
-      <dt style={{ marginBottom: '8px' }}>Disabled</dt>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>Disabled</dt>
       <dd style={{ marginBottom: '24px' }}>
         <BaseButton disabled onClick={action('clicked')} type="button">
           Disabled Button

--- a/src/components/base/Icons/expandMoreIcon.tsx
+++ b/src/components/base/Icons/expandMoreIcon.tsx
@@ -5,7 +5,7 @@ import type { FC } from 'react';
 const SvgExpandMoreIcon: FC<IconProps> = ({ fill, stroke, ...props }) => (
   <svg
     aria-hidden={true}
-    fill={fill !== undefined ? colors[fill] : colors.black}
+    fill={fill !== undefined ? colors[fill] : colors.white}
     height={24}
     stroke={stroke}
     viewBox="0 0 24 24"

--- a/src/components/base/Icons/index.stories.tsx
+++ b/src/components/base/Icons/index.stories.tsx
@@ -8,7 +8,7 @@ const IconList: FC = () => {
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
       {Object.entries(Icons).map(([iconName, IconComponent], index) => (
         <div key={index} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-          <IconComponent fill="white" />
+          <IconComponent />
           <div style={{ color: 'white' }}>{iconName}</div>
         </div>
       ))}

--- a/src/components/base/Icons/index.stories.tsx
+++ b/src/components/base/Icons/index.stories.tsx
@@ -8,8 +8,8 @@ const IconList: FC = () => {
     <div style={{ display: 'flex', flexWrap: 'wrap', gap: '8px' }}>
       {Object.entries(Icons).map(([iconName, IconComponent], index) => (
         <div key={index} style={{ display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-          <IconComponent />
-          <div>{iconName}</div>
+          <IconComponent fill="white" />
+          <div style={{ color: 'white' }}>{iconName}</div>
         </div>
       ))}
     </div>

--- a/src/components/base/Image/index.stories.tsx
+++ b/src/components/base/Image/index.stories.tsx
@@ -59,15 +59,15 @@ const style = sprinkles({
 export const Image: Story = {
   render: () => (
     <dl>
-      <dt>isLazy=true</dt>
+      <dt style={{ color: 'white' }}>isLazy=true</dt>
       <dd style={{ marginBottom: '16px' }}>
         <BaseImage alt={alt} height={height} isLazy={true} sources={sources} width={width} />
       </dd>
-      <dt>isLazy=false</dt>
+      <dt style={{ color: 'white' }}>isLazy=false</dt>
       <dd style={{ marginBottom: '16px' }}>
         <BaseImage alt={alt} height={height} isLazy={false} sources={sources} width={width} />
       </dd>
-      <dt>Custom style</dt>
+      <dt style={{ color: 'white' }}>Custom style</dt>
       <dd style={{ marginBottom: '16px' }}>
         <BaseImage
           alt={alt}

--- a/src/components/base/Image/index.stories.tsx
+++ b/src/components/base/Image/index.stories.tsx
@@ -53,7 +53,7 @@ const height: ComponentProps<typeof BaseImage>['height'] = {
 const style = sprinkles({
   display: 'inline-block',
   padding: 2,
-  backgroundColor: 'lightBlue',
+  backgroundColor: 'white',
 });
 
 export const Image: Story = {

--- a/src/components/base/Text/index.stories.tsx
+++ b/src/components/base/Text/index.stories.tsx
@@ -37,14 +37,11 @@ export const Text: Story = {
         <BaseText color="white" tag="p">
           color=&quot;white&quot;
         </BaseText>
-        <BaseText color="black" tag="p">
-          color=&quot;black&quot;
-        </BaseText>
         <BaseText color="red" tag="p">
           color=&quot;red&quot;
         </BaseText>
-        <BaseText color="darkGray" tag="p">
-          color=&quot;darkGray&quot;
+        <BaseText color="lightGray" tag="p">
+          color=&quot;lightGray&quot;
         </BaseText>
       </dd>
     </dl>

--- a/src/components/base/Text/index.stories.tsx
+++ b/src/components/base/Text/index.stories.tsx
@@ -12,27 +12,27 @@ type Story = StoryObj<typeof BaseText>;
 export const Text: Story = {
   render: () => (
     <dl>
-      <dt style={{ marginBottom: '8px' }}>Tag</dt>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>Tag</dt>
       <dd style={{ marginBottom: '24px' }}>
         <BaseText>tag=&quot;span&quot;</BaseText>
         <BaseText tag="p">tag=&quot;p&quot;</BaseText>
         <BaseText tag="div">tag=&quot;div&quot;</BaseText>
       </dd>
-      <dt style={{ marginBottom: '8px' }}>Font Weight</dt>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>Font Weight</dt>
       <dd style={{ marginBottom: '24px' }}>
         <BaseText tag="p">fontWeight=&quot;normal&quot;</BaseText>
         <BaseText fontWeight="bold" tag="p">
           fontWeight=&quot;bold&quot;
         </BaseText>
       </dd>
-      <dt style={{ marginBottom: '8px' }}>Font Style</dt>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>Font Style</dt>
       <dd style={{ marginBottom: '24px' }}>
         <BaseText tag="p">fontStyle=&quot;normal&quot;</BaseText>
         <BaseText fontStyle="italic" tag="p">
           fontStyle=&quot;italic&quot;
         </BaseText>
       </dd>
-      <dt style={{ marginBottom: '8px' }}>Color</dt>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>Color</dt>
       <dd style={{ marginBottom: '24px' }}>
         <BaseText color="white" tag="p">
           color=&quot;white&quot;

--- a/src/components/base/Text/index.tsx
+++ b/src/components/base/Text/index.tsx
@@ -29,7 +29,7 @@ const Text: FC<Props> = ({
   tag = 'span',
   fontWeight = 'normal',
   fontStyle = 'normal',
-  color = 'black',
+  color = 'white',
   children,
 }) => {
   const className = styles({

--- a/src/components/base/Text/styles.css.ts
+++ b/src/components/base/Text/styles.css.ts
@@ -5,7 +5,7 @@ import { sprinkles } from '@/styles/sprinkles.css';
 import type { Color } from '@/styles/themes.css';
 
 export type TextFontWeight = 'normal' | 'bold';
-export type TextColor = Extract<Color, 'white' | 'black' | 'red' | 'darkGray'>;
+export type TextColor = Extract<Color, 'white' | 'red' | 'lightGray'>;
 export type TextDisplay = 'block' | 'inlineBlock';
 export type TextFontStyle = 'normal' | 'italic';
 
@@ -22,14 +22,11 @@ const color: { [Key in TextColor]: string } = {
   white: sprinkles({
     color: 'white',
   }),
-  black: sprinkles({
-    color: 'black',
-  }),
   red: sprinkles({
     color: 'red',
   }),
-  darkGray: sprinkles({
-    color: 'darkGray',
+  lightGray: sprinkles({
+    color: 'lightGray',
   }),
 };
 

--- a/src/components/case/TechnologyBadge/index.stories.tsx
+++ b/src/components/case/TechnologyBadge/index.stories.tsx
@@ -12,11 +12,11 @@ type Story = StoryObj<typeof CaseTechnologyBadge>;
 export const TechnologyBadge: Story = {
   render: () => (
     <dl>
-      <dt style={{ marginBottom: '8px' }}>label=&quot;expo&quot;</dt>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>label=&quot;expo&quot;</dt>
       <dd style={{ marginBottom: '24px' }}>
         <CaseTechnologyBadge label="expo" />
       </dd>
-      <dt style={{ marginBottom: '8px' }}>label=&quot;fastApi&quot;</dt>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>label=&quot;fastApi&quot;</dt>
       <dd style={{ marginBottom: '24px' }}>
         <CaseTechnologyBadge label="fastApi" />
       </dd>

--- a/src/components/common/Accordion/index.stories.tsx
+++ b/src/components/common/Accordion/index.stories.tsx
@@ -15,13 +15,13 @@ export const Accordion: Story = {
   render: () => (
     <>
       <CommonAccordion buttonText="2023" isOpen={true}>
-        {'isOpen={true}'}
+        <div style={{ color: 'white' }}>{'isOpen={true}'}</div>
       </CommonAccordion>
       <CommonAccordion buttonText="2022" isOpen={false}>
-        {'isOpen={false}'}
+        <div style={{ color: 'white' }}>{'isOpen={false}'}</div>
       </CommonAccordion>
       <CommonAccordion buttonText="2021" isOpen={isDesktop()}>
-        {'isOpen={isDesktop()} // 画面幅に応じて制御'}
+        <div style={{ color: 'white' }}>{'isOpen={isDesktop()} // 画面幅に応じて制御'}</div>
       </CommonAccordion>
     </>
   ),

--- a/src/components/common/Accordion/styles.css.ts
+++ b/src/components/common/Accordion/styles.css.ts
@@ -15,7 +15,7 @@ const styles = {
         mobile: 24,
         desktop: 36,
       },
-      color: 'black',
+      color: 'white',
       outlineColor: {
         focusVisible: 'blue',
       },

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -6,7 +6,6 @@ export const colors = {
   gray: '#94989B',
   lightGray: '#E2E2E2',
   blue: '#1E1ADE',
-  lightBlue: '#0080FF',
   hoverBlue: 'rgba(11, 96, 223, 0.8)',
   red: '#FF4747',
   gradientBlue: 'linear-gradient(#0078B7, #001E43)',

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -6,7 +6,7 @@ export const colors = {
   black: '#333333',
   silver: '#F8F8F8',
   gray: '#94989B',
-  darkGray: '#656565',
+  lightGray: '#E2E2E2',
   blue: '#1E1ADE',
   lightBlue: '#0080FF',
   hoverBlue: 'rgba(11, 96, 223, 0.8)',

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -3,7 +3,6 @@ import { createGlobalTheme } from '@vanilla-extract/css';
 export const colors = {
   white: '#FEFEFE',
   hoverWhite: 'rgba(255, 255, 255, 0.25)',
-  black: '#333333',
   silver: '#F8F8F8',
   gray: '#94989B',
   lightGray: '#E2E2E2',

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -3,16 +3,12 @@ import { createGlobalTheme } from '@vanilla-extract/css';
 export const colors = {
   white: '#FEFEFE',
   hoverWhite: 'rgba(255, 255, 255, 0.25)',
-  silver: '#F8F8F8',
   gray: '#94989B',
   lightGray: '#E2E2E2',
   blue: '#1E1ADE',
   lightBlue: '#0080FF',
   hoverBlue: 'rgba(11, 96, 223, 0.8)',
-  indigo: '#0054A6',
-  purple: '#B01CF6',
   red: '#FF4747',
-  lightRed: '#FBD4D4',
   gradientBlue: 'linear-gradient(#0078B7, #001E43)',
   transparent: 'transparent',
 } as const;


### PR DESCRIPTION
ref #305 

## 概要

Figmaのデザイン変更に伴って文字色のカラーを白ベースにしました。また、使用しなくなったカラーを削除しました。

※ 別PRでカラーのkey名は修正します🙏

## スナップショット

主要な変更以外は割愛します🙏

### Badge

背景色をなくしました（背景色は親側から`className`を渡すことで付与する。TechnologyBadgeを参照）

<img width="928" alt="Storybook上に表示されたBadgeコンポーネント" src="https://github.com/uyupun/official/assets/30039352/93dff888-b3e3-43e3-be31-14cfa070e2ac">


### Text

ベースを白に変更。かつ、使用するカラーを追加・修正しました。

<img width="931" alt="Storybook上に表示されたTextコンポーネント" src="https://github.com/uyupun/official/assets/30039352/73ebbe5b-6b35-434e-812a-e848486ff941">


### Accordion

ベースを白に変更。かつ、アイコンのカラーも修正しました。

<img width="936" alt="Storybook上に表示されたAccordionコンポーネント" src="https://github.com/uyupun/official/assets/30039352/84b7cade-ace4-412d-973a-dd6c31723bfe">
