### PR TITLE
modern-css-resetのアンインストールとreset.cssの作成

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { colors } from '../src/styles/themes.css';
 
 import type { Parameters } from '@storybook/react';
+import '../src/styles/reset.css';
 
 export const parameters: Parameters = {
   controls: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -4,7 +4,6 @@ import React from 'react';
 import { colors } from '../src/styles/themes.css';
 
 import type { Parameters } from '@storybook/react';
-import 'modern-css-reset/dist/reset.min.css';
 
 export const parameters: Parameters = {
   controls: {

--- a/docs/tech.md
+++ b/docs/tech.md
@@ -28,7 +28,7 @@
 
 ## スタイリング
 
-- [modern-css-reset](https://github.com/hankchizljaw/modern-css-reset)
+- [modern-css-reset](https://piccalil.li/blog/a-more-modern-css-reset)
 - [vanilla-extract](https://vanilla-extract.style)
   - [Sprinkles](https://vanilla-extract.style/documentation/packages/sprinkles)
   - [Recipes](https://vanilla-extract.style/documentation/packages/recipes)

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
     "lint-staged": "^12.1.2",
     "micromatch": "^4.0.5",
     "minimist": "^1.2.8",
-    "modern-css-reset": "^1.4.0",
     "pathpida": "^0.20.1",
     "prettier": "^2.8.3",
     "serve": "^14.2.1",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,3 +1,4 @@
+import '@/styles/reset.css';
 import Head from 'next/head';
 
 import { cica } from '@/styles/font';

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,3 @@
-import 'modern-css-reset/dist/reset.min.css';
 import Head from 'next/head';
 
 import { cica } from '@/styles/font';

--- a/src/styles/reset.css
+++ b/src/styles/reset.css
@@ -1,0 +1,89 @@
+/* Box sizing rules */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+/* Prevent font size inflation */
+html {
+  -moz-text-size-adjust: none;
+  -webkit-text-size-adjust: none;
+  text-size-adjust: none;
+}
+
+/* Remove default margin in favour of better control in authored CSS */
+body,
+h1,
+h2,
+h3,
+h4,
+p,
+figure,
+blockquote,
+dl,
+dd {
+  margin-block-end: 0;
+}
+
+/* Remove list styles on ul, ol elements with a list role, which suggests default styling will be removed */
+ul[role='list'],
+ol[role='list'] {
+  list-style: none;
+}
+
+/* Set core body defaults */
+body {
+  min-height: 100vh;
+  line-height: 1.5;
+}
+
+/* Set shorter line heights on headings and interactive elements */
+h1,
+h2,
+h3,
+h4,
+button,
+input,
+label {
+  line-height: 1.1;
+}
+
+/* Balance text wrapping on headings */
+h1,
+h2,
+h3,
+h4 {
+  text-wrap: balance;
+}
+
+/* A elements that don't have a class get default styles */
+a:not([class]) {
+  text-decoration-skip-ink: auto;
+  color: currentColor;
+}
+
+/* Make images easier to work with */
+img,
+picture {
+  max-width: 100%;
+  display: block;
+}
+
+/* Inherit fonts for inputs and buttons */
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+/* Make sure text areas without a rows attribute are not tiny */
+textarea:not([rows]) {
+  min-height: 10em;
+}
+
+/* Anything that has been anchored to should have extra scroll margin */
+:target {
+  scroll-margin-block: 5ex;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -12764,13 +12764,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"modern-css-reset@npm:^1.4.0":
-  version: 1.4.0
-  resolution: "modern-css-reset@npm:1.4.0"
-  checksum: b69603972fd4b5f03ced962c0c6c81447b2f343e33b396e86413501c14a873b20c532337b21fa0a7017a24c37fe134482e3dae36feb549f28bc02bd46adbc40b
-  languageName: node
-  linkType: hard
-
 "mri@npm:^1.2.0":
   version: 1.2.0
   resolution: "mri@npm:1.2.0"
@@ -13233,7 +13226,6 @@ __metadata:
     lint-staged: "npm:^12.1.2"
     micromatch: "npm:^4.0.5"
     minimist: "npm:^1.2.8"
-    modern-css-reset: "npm:^1.4.0"
     next: "npm:14.0.3"
     pathpida: "npm:^0.20.1"
     prettier: "npm:^2.8.3"


### PR DESCRIPTION
close #310 

## 概要

modern-css-resetがアーカイブされたためアンインストールし、作者が誘導していた[https://piccalil.li/blog/a-more-modern-css-reset/](https://piccalil.li/blog/a-more-modern-css-reset/)内のCSSを使用するようにしました。

※ vanilla-extractの`globalStyle`を使用してみたが`text-wrap`に対応していなかったため、CSSファイルとして追加しました