### PR TITLE
背景をグラデーションにする

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -6,6 +6,8 @@ import { cica } from '@/styles/font';
 import type { AppProps } from 'next/app';
 import type { FC } from 'react';
 
+import '@/styles/layout.css';
+
 const MyApp: FC<AppProps> = ({ Component, pageProps }) => {
   return (
     <>

--- a/src/styles/layout.css.ts
+++ b/src/styles/layout.css.ts
@@ -5,7 +5,7 @@ globalStyle('body', {
   background: 'linear-gradient(to bottom, #0078B7 0, #001E43 667px, #001E43 100%)',
   '@media': {
     'screen and (min-width: 768px)': {
-      background: 'linear-gradient(to bottom, #0078B7 0, #001E43 1024px, #001E43 100%)',
+      background: 'linear-gradient(to bottom, #0078B7 0, #001E43 1080px, #001E43 100%)',
     },
   },
 });

--- a/src/styles/layout.css.ts
+++ b/src/styles/layout.css.ts
@@ -1,0 +1,11 @@
+import { globalStyle } from '@vanilla-extract/css';
+
+globalStyle('body', {
+  minHeight: '100dvh',
+  background: 'linear-gradient(to bottom, #0078B7 0, #001E43 667px, #001E43 100%)',
+  '@media': {
+    'screen and (min-width: 768px)': {
+      background: 'linear-gradient(to bottom, #0078B7 0, #001E43 1024px, #001E43 100%)',
+    },
+  },
+});


### PR DESCRIPTION
close #308 

## 概要

CSSをグラデーションにしましたので確認お願いします。

※ 当初はコンポーネントで対応しようと思ってましたが、CSSオンリーで対応できたので特にコンポーネント化はしてません。

## スクリーンショット

### PC

<img width="1000" alt="青のグラデーションの背景にofficialの文字が記載されたWebサイトの画面。PCサイズ。" src="https://github.com/uyupun/official/assets/30039352/e9e785c7-ed0c-41ee-aa4c-161b7a2bf02b">

### SP

<img width="375" alt="青のグラデーションの背景にofficialの文字が記載されたWebサイトの画面。スマホサイズ。"  src="https://github.com/uyupun/official/assets/30039352/31223135-7216-4db7-b1ac-03027fe600de">