### PR TITLE
Heading / Text コンポーネントのリファクタリング

### DIFF
--- a/src/components/base/Heading/index.stories.tsx
+++ b/src/components/base/Heading/index.stories.tsx
@@ -13,7 +13,7 @@ export const Heading: Story = {
   render: () => (
     <div>
       <BaseHeading>Heading level 1</BaseHeading>
-      <BaseHeading tag="h2">Heading level 2</BaseHeading>
+      <BaseHeading tagName="h2">Heading level 2</BaseHeading>
     </div>
   ),
 };

--- a/src/components/base/Heading/index.tsx
+++ b/src/components/base/Heading/index.tsx
@@ -20,12 +20,11 @@ type BaseProps<T extends TagName> = {
 type Props<T extends TagName> = BaseProps<T> &
   Omit<ComponentPropsWithoutRef<T>, keyof BaseProps<T>>;
 
-const Heading: FC<Props<TagName>> = ({ tag = 'h1', children, className, ...rest }) => {
-  const Component = tag;
+const Heading: FC<Props<TagName>> = ({ tag: Tag = 'h1', children, className, ...rest }) => {
   return (
-    <Component className={clsx(styles.common, styles[tag], className)} {...rest}>
+    <Tag className={clsx(styles.common, styles[Tag], className)} {...rest}>
       {children}
-    </Component>
+    </Tag>
   );
 };
 

--- a/src/components/base/Heading/index.tsx
+++ b/src/components/base/Heading/index.tsx
@@ -2,25 +2,33 @@ import clsx from 'clsx';
 
 import { styles } from './styles.css';
 
-import type { FC, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
 
-type Props = {
+type Props<T extends 'h1' | 'h2'> = {
   /**
    * 見出しのタグ
    */
-  tag?: 'h1' | 'h2';
+  tag?: T;
   /**
    * 見出しのコンテンツ
    */
   children: ReactNode;
-};
+} & Omit<ComponentPropsWithoutRef<T>, 'tag' | 'children'>;
 
-const Heading: FC<Props> = ({ tag = 'h1', children }) => {
+const Heading: FC<Props<'h1' | 'h2'>> = ({ tag = 'h1', children, className, ...rest }) => {
   switch (tag) {
     case 'h1':
-      return <h1 className={clsx(styles.common, styles.h1)}>{children}</h1>;
+      return (
+        <h1 className={clsx(styles.common, styles.h1, className)} {...rest}>
+          {children}
+        </h1>
+      );
     case 'h2':
-      return <h2 className={clsx(styles.common, styles.h2)}>{children}</h2>;
+      return (
+        <h2 className={clsx(styles.common, styles.h2, className)} {...rest}>
+          {children}
+        </h2>
+      );
   }
 };
 

--- a/src/components/base/Heading/index.tsx
+++ b/src/components/base/Heading/index.tsx
@@ -4,7 +4,9 @@ import { styles } from './styles.css';
 
 import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
 
-type Props<T extends 'h1' | 'h2'> = {
+type Tag = 'h1' | 'h2';
+
+type BaseProps<T extends Tag> = {
   /**
    * 見出しのタグ
    */
@@ -13,9 +15,11 @@ type Props<T extends 'h1' | 'h2'> = {
    * 見出しのコンテンツ
    */
   children: ReactNode;
-} & Omit<ComponentPropsWithoutRef<T>, 'tag' | 'children'>;
+};
 
-const Heading: FC<Props<'h1' | 'h2'>> = ({ tag = 'h1', children, className, ...rest }) => {
+type Props<T extends Tag> = BaseProps<T> & Omit<ComponentPropsWithoutRef<T>, keyof BaseProps<T>>;
+
+const Heading: FC<Props<Tag>> = ({ tag = 'h1', children, className, ...rest }) => {
   const Component = tag;
   return (
     <Component className={clsx(styles.common, styles[tag], className)} {...rest}>

--- a/src/components/base/Heading/index.tsx
+++ b/src/components/base/Heading/index.tsx
@@ -16,20 +16,12 @@ type Props<T extends 'h1' | 'h2'> = {
 } & Omit<ComponentPropsWithoutRef<T>, 'tag' | 'children'>;
 
 const Heading: FC<Props<'h1' | 'h2'>> = ({ tag = 'h1', children, className, ...rest }) => {
-  switch (tag) {
-    case 'h1':
-      return (
-        <h1 className={clsx(styles.common, styles.h1, className)} {...rest}>
-          {children}
-        </h1>
-      );
-    case 'h2':
-      return (
-        <h2 className={clsx(styles.common, styles.h2, className)} {...rest}>
-          {children}
-        </h2>
-      );
-  }
+  const Component = tag;
+  return (
+    <Component className={clsx(styles.common, styles[tag], className)} {...rest}>
+      {children}
+    </Component>
+  );
 };
 
 export { Heading };

--- a/src/components/base/Heading/index.tsx
+++ b/src/components/base/Heading/index.tsx
@@ -10,7 +10,7 @@ type BaseProps<T extends TagName> = {
   /**
    * 見出しのタグ
    */
-  tag?: T;
+  tagName?: T;
   /**
    * 見出しのコンテンツ
    */
@@ -20,11 +20,11 @@ type BaseProps<T extends TagName> = {
 type Props<T extends TagName> = BaseProps<T> &
   Omit<ComponentPropsWithoutRef<T>, keyof BaseProps<T>>;
 
-const Heading: FC<Props<TagName>> = ({ tag: Tag = 'h1', children, className, ...rest }) => {
+const Heading: FC<Props<TagName>> = ({ tagName: TagName = 'h1', children, className, ...rest }) => {
   return (
-    <Tag className={clsx(styles.common, styles[Tag], className)} {...rest}>
+    <TagName className={clsx(styles.common, styles[TagName], className)} {...rest}>
       {children}
-    </Tag>
+    </TagName>
   );
 };
 

--- a/src/components/base/Heading/index.tsx
+++ b/src/components/base/Heading/index.tsx
@@ -4,9 +4,9 @@ import { styles } from './styles.css';
 
 import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
 
-type Tag = 'h1' | 'h2';
+type TagName = 'h1' | 'h2';
 
-type BaseProps<T extends Tag> = {
+type BaseProps<T extends TagName> = {
   /**
    * 見出しのタグ
    */
@@ -17,9 +17,10 @@ type BaseProps<T extends Tag> = {
   children: ReactNode;
 };
 
-type Props<T extends Tag> = BaseProps<T> & Omit<ComponentPropsWithoutRef<T>, keyof BaseProps<T>>;
+type Props<T extends TagName> = BaseProps<T> &
+  Omit<ComponentPropsWithoutRef<T>, keyof BaseProps<T>>;
 
-const Heading: FC<Props<Tag>> = ({ tag = 'h1', children, className, ...rest }) => {
+const Heading: FC<Props<TagName>> = ({ tag = 'h1', children, className, ...rest }) => {
   const Component = tag;
   return (
     <Component className={clsx(styles.common, styles[tag], className)} {...rest}>

--- a/src/components/base/Text/index.stories.tsx
+++ b/src/components/base/Text/index.stories.tsx
@@ -14,33 +14,33 @@ export const Text: Story = {
     <dl>
       <dt style={{ color: 'white', marginBottom: '8px' }}>Tag</dt>
       <dd style={{ marginBottom: '24px' }}>
-        <BaseText>tag=&quot;span&quot;</BaseText>
-        <BaseText tag="p">tag=&quot;p&quot;</BaseText>
-        <BaseText tag="div">tag=&quot;div&quot;</BaseText>
+        <BaseText>tagName=&quot;span&quot;</BaseText>
+        <BaseText tagName="p">tagName=&quot;p&quot;</BaseText>
+        <BaseText tagName="div">tagName=&quot;div&quot;</BaseText>
       </dd>
       <dt style={{ color: 'white', marginBottom: '8px' }}>Font Weight</dt>
       <dd style={{ marginBottom: '24px' }}>
-        <BaseText tag="p">fontWeight=&quot;normal&quot;</BaseText>
-        <BaseText fontWeight="bold" tag="p">
+        <BaseText tagName="p">fontWeight=&quot;normal&quot;</BaseText>
+        <BaseText fontWeight="bold" tagName="p">
           fontWeight=&quot;bold&quot;
         </BaseText>
       </dd>
       <dt style={{ color: 'white', marginBottom: '8px' }}>Font Style</dt>
       <dd style={{ marginBottom: '24px' }}>
-        <BaseText tag="p">fontStyle=&quot;normal&quot;</BaseText>
-        <BaseText fontStyle="italic" tag="p">
+        <BaseText tagName="p">fontStyle=&quot;normal&quot;</BaseText>
+        <BaseText fontStyle="italic" tagName="p">
           fontStyle=&quot;italic&quot;
         </BaseText>
       </dd>
       <dt style={{ color: 'white', marginBottom: '8px' }}>Color</dt>
       <dd style={{ marginBottom: '24px' }}>
-        <BaseText color="white" tag="p">
+        <BaseText color="white" tagName="p">
           color=&quot;white&quot;
         </BaseText>
-        <BaseText color="red" tag="p">
+        <BaseText color="red" tagName="p">
           color=&quot;red&quot;
         </BaseText>
-        <BaseText color="lightGray" tag="p">
+        <BaseText color="lightGray" tagName="p">
           color=&quot;lightGray&quot;
         </BaseText>
       </dd>

--- a/src/components/base/Text/index.tsx
+++ b/src/components/base/Text/index.tsx
@@ -46,27 +46,13 @@ const Text: FC<Props<Tag>> = ({
     display: tag === 'span' ? 'inlineBlock' : 'block',
     fontStyle,
   });
+  const Component = tag;
 
-  switch (tag) {
-    case 'span':
-      return (
-        <span className={clsx(style, className)} {...rest}>
-          {children}
-        </span>
-      );
-    case 'p':
-      return (
-        <p className={clsx(style, className)} {...rest}>
-          {children}
-        </p>
-      );
-    case 'div':
-      return (
-        <div className={clsx(style, className)} {...rest}>
-          {children}
-        </div>
-      );
-  }
+  return (
+    <Component className={clsx(style, className)} {...rest}>
+      {children}
+    </Component>
+  );
 };
 
 export { Text };

--- a/src/components/base/Text/index.tsx
+++ b/src/components/base/Text/index.tsx
@@ -33,7 +33,7 @@ type Props<T extends TagName> = BaseProps<T> &
   Omit<ComponentPropsWithoutRef<T>, keyof BaseProps<T>>;
 
 const Text: FC<Props<TagName>> = ({
-  tag = 'span',
+  tag: Tag = 'span',
   fontWeight = 'normal',
   fontStyle = 'normal',
   color = 'white',
@@ -44,15 +44,14 @@ const Text: FC<Props<TagName>> = ({
   const style = styles({
     color,
     fontWeight,
-    display: tag === 'span' ? 'inlineBlock' : 'block',
+    display: Tag === 'span' ? 'inlineBlock' : 'block',
     fontStyle,
   });
-  const Component = tag;
 
   return (
-    <Component className={clsx(style, className)} {...rest}>
+    <Tag className={clsx(style, className)} {...rest}>
       {children}
-    </Component>
+    </Tag>
   );
 };
 

--- a/src/components/base/Text/index.tsx
+++ b/src/components/base/Text/index.tsx
@@ -4,9 +4,9 @@ import { styles, type TextColor, type TextFontStyle, type TextFontWeight } from 
 
 import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
 
-type Tag = 'span' | 'p' | 'div';
+type TagName = 'span' | 'p' | 'div';
 
-type BaseProps<T extends Tag> = {
+type BaseProps<T extends TagName> = {
   /**
    * テキストのタグ
    */
@@ -29,9 +29,10 @@ type BaseProps<T extends Tag> = {
   children: ReactNode;
 };
 
-type Props<T extends Tag> = BaseProps<T> & Omit<ComponentPropsWithoutRef<T>, keyof BaseProps<T>>;
+type Props<T extends TagName> = BaseProps<T> &
+  Omit<ComponentPropsWithoutRef<T>, keyof BaseProps<T>>;
 
-const Text: FC<Props<Tag>> = ({
+const Text: FC<Props<TagName>> = ({
   tag = 'span',
   fontWeight = 'normal',
   fontStyle = 'normal',

--- a/src/components/base/Text/index.tsx
+++ b/src/components/base/Text/index.tsx
@@ -1,12 +1,16 @@
+import clsx from 'clsx';
+
 import { styles, type TextColor, type TextFontStyle, type TextFontWeight } from './styles.css';
 
-import type { FC, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
 
-type Props = {
+type Tag = 'span' | 'p' | 'div';
+
+type BaseProps<T extends Tag> = {
   /**
    * テキストのタグ
    */
-  tag?: 'span' | 'p' | 'div';
+  tag?: T;
   /**
    * テキストの太さ
    */
@@ -25,14 +29,18 @@ type Props = {
   children: ReactNode;
 };
 
-const Text: FC<Props> = ({
+type Props<T extends Tag> = BaseProps<T> & Omit<ComponentPropsWithoutRef<T>, keyof BaseProps<T>>;
+
+const Text: FC<Props<Tag>> = ({
   tag = 'span',
   fontWeight = 'normal',
   fontStyle = 'normal',
   color = 'white',
   children,
+  className,
+  ...rest
 }) => {
-  const className = styles({
+  const style = styles({
     color,
     fontWeight,
     display: tag === 'span' ? 'inlineBlock' : 'block',
@@ -41,11 +49,23 @@ const Text: FC<Props> = ({
 
   switch (tag) {
     case 'span':
-      return <span className={className}>{children}</span>;
+      return (
+        <span className={clsx(style, className)} {...rest}>
+          {children}
+        </span>
+      );
     case 'p':
-      return <p className={className}>{children}</p>;
+      return (
+        <p className={clsx(style, className)} {...rest}>
+          {children}
+        </p>
+      );
     case 'div':
-      return <div className={className}>{children}</div>;
+      return (
+        <div className={clsx(style, className)} {...rest}>
+          {children}
+        </div>
+      );
   }
 };
 

--- a/src/components/base/Text/index.tsx
+++ b/src/components/base/Text/index.tsx
@@ -10,7 +10,7 @@ type BaseProps<T extends TagName> = {
   /**
    * テキストのタグ
    */
-  tag?: T;
+  tagName?: T;
   /**
    * テキストの太さ
    */
@@ -33,7 +33,7 @@ type Props<T extends TagName> = BaseProps<T> &
   Omit<ComponentPropsWithoutRef<T>, keyof BaseProps<T>>;
 
 const Text: FC<Props<TagName>> = ({
-  tag: Tag = 'span',
+  tagName: TagName = 'span',
   fontWeight = 'normal',
   fontStyle = 'normal',
   color = 'white',
@@ -44,14 +44,14 @@ const Text: FC<Props<TagName>> = ({
   const style = styles({
     color,
     fontWeight,
-    display: Tag === 'span' ? 'inlineBlock' : 'block',
+    display: TagName === 'span' ? 'inlineBlock' : 'block',
     fontStyle,
   });
 
   return (
-    <Tag className={clsx(style, className)} {...rest}>
+    <TagName className={clsx(style, className)} {...rest}>
       {children}
-    </Tag>
+    </TagName>
   );
 };
 


### PR DESCRIPTION
## 概要

Heading / Text コンポーネントで、ジェネリクスを使用してタグを識別し、それによって `ComponentPropsWithoutRef` の引数をタグに沿ったものにしました。これにより、タグの属性を引数に当てることができるようになります。
また、Switch文を削除し、タグをそのまま用いるようにしました。

デザインの修正はしていないため、スクリーンショットは割愛。