### PR TITLE
TextコンポーネントのstoriesでTagからTag Nameに修正

### DIFF
--- a/src/components/base/Text/index.stories.tsx
+++ b/src/components/base/Text/index.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof BaseText>;
 export const Text: Story = {
   render: () => (
     <dl>
-      <dt style={{ color: 'white', marginBottom: '8px' }}>Tag</dt>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>Tag Name</dt>
       <dd style={{ marginBottom: '24px' }}>
         <BaseText>tag=&quot;span&quot;</BaseText>
         <BaseText tag="p">tag=&quot;p&quot;</BaseText>


### PR DESCRIPTION
## 概要

タイトル通り、Textコンポーネントのstories内で使用している文字をTagからTag Nameに修正しました。

## スクリーンショット

<img width="848" alt="Storybook上にTextコンポーネントが表示されている。修正箇所のTag Nameの文字が赤枠で囲まれている。" src="https://github.com/uyupun/official/assets/30039352/996923a8-7a96-4cb4-9beb-2149db5884c0">
