### PR TITLE
Textコンポーネントにline-heightとfont-sizeを指定するpropsを追加

### DIFF
--- a/src/components/base/Text/index.stories.tsx
+++ b/src/components/base/Text/index.stories.tsx
@@ -44,6 +44,45 @@ export const Text: Story = {
           color=&quot;lightGray&quot;
         </BaseText>
       </dd>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>Line Height</dt>
+      <dd style={{ marginBottom: '24px' }}>
+        <BaseText lineHeight={1} tagName="p">
+          lineHeight=&#123;1&#125;
+        </BaseText>
+        <BaseText lineHeight={1.3} tagName="p">
+          lineHeight=&#123;1.3&#125;
+        </BaseText>
+        <BaseText lineHeight={1.8} tagName="p">
+          lineHeight=&#123;1.8&#125;
+        </BaseText>
+      </dd>
+      <dt style={{ color: 'white', marginBottom: '8px' }}>Font Size</dt>
+      <dd style={{ marginBottom: '24px' }}>
+        <BaseText fontSize={{ mobile: 10, desktop: 10 }} tagName="p">
+          fontSize=&#123;&#123;mobile: 10, desktop: 10&#125;&#125;
+        </BaseText>
+        <BaseText fontSize={{ mobile: 14, desktop: 14 }} tagName="p">
+          fontSize=&#123;&#123;mobile: 14, desktop: 14&#125;&#125;
+        </BaseText>
+        <BaseText fontSize={{ mobile: 16, desktop: 16 }} tagName="p">
+          fontSize=&#123;&#123;mobile: 16, desktop: 16&#125;&#125;
+        </BaseText>
+        <BaseText fontSize={{ mobile: 18, desktop: 18 }} tagName="p">
+          fontSize=&#123;&#123;mobile: 18, desktop: 18&#125;&#125;
+        </BaseText>
+        <BaseText fontSize={{ mobile: 20, desktop: 20 }} tagName="p">
+          fontSize=&#123;&#123;mobile: 20, desktop: 20&#125;&#125;
+        </BaseText>
+        <BaseText fontSize={{ mobile: 20, desktop: 24 }} tagName="p">
+          fontSize=&#123;&#123;mobile: 20, desktop: 24&#125;&#125;
+        </BaseText>
+        <BaseText fontSize={{ mobile: 20, desktop: 32 }} tagName="p">
+          fontSize=&#123;&#123;mobile: 20, desktop: 32&#125;&#125;
+        </BaseText>
+        <BaseText fontSize={{ mobile: 20, desktop: 36 }} tagName="p">
+          fontSize=&#123;&#123;mobile: 20, desktop: 36&#125;&#125;
+        </BaseText>
+      </dd>
     </dl>
   ),
 };

--- a/src/components/base/Text/index.tsx
+++ b/src/components/base/Text/index.tsx
@@ -1,5 +1,7 @@
 import clsx from 'clsx';
 
+import { type LineHeight } from '@/styles/themes.css';
+
 import { styles, type TextColor, type TextFontStyle, type TextFontWeight } from './styles.css';
 
 import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
@@ -24,6 +26,10 @@ type BaseProps<T extends TagName> = {
    */
   color?: TextColor;
   /**
+   * テキストの行間
+   */
+  lineHeight?: LineHeight;
+  /**
    * テキストのコンテンツ
    */
   children: ReactNode;
@@ -37,6 +43,7 @@ const Text: FC<Props<TagName>> = ({
   fontWeight = 'normal',
   fontStyle = 'normal',
   color = 'white',
+  lineHeight = 1.8,
   children,
   className,
   ...rest
@@ -46,6 +53,7 @@ const Text: FC<Props<TagName>> = ({
     fontWeight,
     display: TagName === 'span' ? 'inlineBlock' : 'block',
     fontStyle,
+    lineHeight,
   });
 
   return (

--- a/src/components/base/Text/index.tsx
+++ b/src/components/base/Text/index.tsx
@@ -2,11 +2,23 @@ import clsx from 'clsx';
 
 import { type LineHeight } from '@/styles/themes.css';
 
-import { styles, type TextColor, type TextFontStyle, type TextFontWeight } from './styles.css';
+import {
+  styles,
+  type TextColor,
+  type TextFontSizeDesktop,
+  type TextFontSizeMobile,
+  type TextFontStyle,
+  type TextFontWeight,
+} from './styles.css';
 
 import type { ComponentPropsWithoutRef, FC, ReactNode } from 'react';
 
 type TagName = 'span' | 'p' | 'div';
+
+type FontSize = {
+  mobile: TextFontSizeMobile;
+  desktop: TextFontSizeDesktop;
+};
 
 type BaseProps<T extends TagName> = {
   /**
@@ -30,6 +42,10 @@ type BaseProps<T extends TagName> = {
    */
   lineHeight?: LineHeight;
   /**
+   * テキストのフォントサイズ
+   */
+  fontSize?: FontSize;
+  /**
    * テキストのコンテンツ
    */
   children: ReactNode;
@@ -44,6 +60,10 @@ const Text: FC<Props<TagName>> = ({
   fontStyle = 'normal',
   color = 'white',
   lineHeight = 1.8,
+  fontSize = {
+    mobile: 14,
+    desktop: 16,
+  },
   children,
   className,
   ...rest
@@ -54,6 +74,8 @@ const Text: FC<Props<TagName>> = ({
     display: TagName === 'span' ? 'inlineBlock' : 'block',
     fontStyle,
     lineHeight,
+    fontSizeMobile: fontSize.mobile,
+    fontSizeDesktop: fontSize.desktop,
   });
 
   return (

--- a/src/components/base/Text/styles.css.ts
+++ b/src/components/base/Text/styles.css.ts
@@ -2,12 +2,14 @@ import { recipe } from '@vanilla-extract/recipes';
 
 import { sprinkles } from '@/styles/sprinkles.css';
 
-import type { Color, LineHeight } from '@/styles/themes.css';
+import type { Color, FontSize, LineHeight } from '@/styles/themes.css';
 
 export type TextFontWeight = 'normal' | 'bold';
 export type TextColor = Extract<Color, 'white' | 'red' | 'lightGray'>;
 export type TextDisplay = 'block' | 'inlineBlock';
 export type TextFontStyle = 'normal' | 'italic';
+export type TextFontSizeMobile = Extract<FontSize, 10 | 14 | 16 | 18 | 20>;
+export type TextFontSizeDesktop = Extract<FontSize, 10 | 14 | 16 | 18 | 20 | 24 | 32 | 36>;
 
 const fontWeight: { [Key in TextFontWeight]: string } = {
   normal: sprinkles({
@@ -60,19 +62,86 @@ const lineHeight: { [Key in LineHeight]: string } = {
   }),
 };
 
-const styles = recipe({
-  base: sprinkles({
+const fontSizeMobile: { [Key in TextFontSizeMobile]: string } = {
+  10: sprinkles({
+    fontSize: {
+      mobile: 10,
+    },
+  }),
+  14: sprinkles({
     fontSize: {
       mobile: 14,
+    },
+  }),
+  16: sprinkles({
+    fontSize: {
+      mobile: 16,
+    },
+  }),
+  18: sprinkles({
+    fontSize: {
+      mobile: 18,
+    },
+  }),
+  20: sprinkles({
+    fontSize: {
+      mobile: 20,
+    },
+  }),
+};
+
+const fontSizeDesktop: { [Key in TextFontSizeDesktop]: string } = {
+  10: sprinkles({
+    fontSize: {
+      desktop: 10,
+    },
+  }),
+  14: sprinkles({
+    fontSize: {
+      desktop: 14,
+    },
+  }),
+  16: sprinkles({
+    fontSize: {
       desktop: 16,
     },
   }),
+  18: sprinkles({
+    fontSize: {
+      desktop: 18,
+    },
+  }),
+  20: sprinkles({
+    fontSize: {
+      desktop: 20,
+    },
+  }),
+  24: sprinkles({
+    fontSize: {
+      desktop: 24,
+    },
+  }),
+  32: sprinkles({
+    fontSize: {
+      desktop: 32,
+    },
+  }),
+  36: sprinkles({
+    fontSize: {
+      desktop: 36,
+    },
+  }),
+};
+
+const styles = recipe({
   variants: {
     fontWeight,
     color,
     display,
     fontStyle,
     lineHeight,
+    fontSizeMobile,
+    fontSizeDesktop,
   },
 });
 

--- a/src/components/base/Text/styles.css.ts
+++ b/src/components/base/Text/styles.css.ts
@@ -2,7 +2,7 @@ import { recipe } from '@vanilla-extract/recipes';
 
 import { sprinkles } from '@/styles/sprinkles.css';
 
-import type { Color } from '@/styles/themes.css';
+import type { Color, LineHeight } from '@/styles/themes.css';
 
 export type TextFontWeight = 'normal' | 'bold';
 export type TextColor = Extract<Color, 'white' | 'red' | 'lightGray'>;
@@ -48,9 +48,20 @@ const fontStyle: { [Key in TextFontStyle]: string } = {
   }),
 };
 
+const lineHeight: { [Key in LineHeight]: string } = {
+  1: sprinkles({
+    lineHeight: 1,
+  }),
+  1.3: sprinkles({
+    lineHeight: 1.3,
+  }),
+  1.8: sprinkles({
+    lineHeight: 1.8,
+  }),
+};
+
 const styles = recipe({
   base: sprinkles({
-    lineHeight: 1.8,
     fontSize: {
       mobile: 14,
       desktop: 16,
@@ -61,6 +72,7 @@ const styles = recipe({
     color,
     display,
     fontStyle,
+    lineHeight,
   },
 });
 

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -52,6 +52,8 @@ export const fontSize = {
   64: '4rem',
 } as const;
 
+export type FontSize = keyof typeof fontSize;
+
 export const lineHeight = {
   1: '1',
   1.3: '1.3',

--- a/src/styles/themes.css.ts
+++ b/src/styles/themes.css.ts
@@ -58,6 +58,8 @@ export const lineHeight = {
   1.8: '1.8',
 } as const;
 
+export type LineHeight = keyof typeof lineHeight;
+
 /**
  *  width と height で使用する
  */


### PR DESCRIPTION
## 概要

Textコンポーネントにline-heightとfont-sizeを指定するpropsを追加しましたのでご確認よろしくお願いします。

## 背景

背景として PR #377 でTextコンポーネントのスタイルが優先されたため、デフォルトのスタイルを排除し、使用されるスタイルはすべてPropsとして渡すようにしました。

## スクリーンショット

<img width="1028" alt="StorybookでTextコンポーネントを表示している。" src="https://github.com/uyupun/official/assets/30039352/532caae6-76c8-48a5-8cbf-135b9676a435">
